### PR TITLE
[FEAT] User, SelfDiagnosis, Diary, StressSummary 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/konkuk/strhat/StrhatApplication.java
+++ b/src/main/java/com/konkuk/strhat/StrhatApplication.java
@@ -1,13 +1,23 @@
 package com.konkuk.strhat;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class StrhatApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(StrhatApplication.class, args);
+	}
+
+	@PostConstruct
+	public void setTime() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 
 }

--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -21,20 +21,20 @@ public class Diary {
     private String content;
 
     @Column(name = "emotion", nullable = false)
-    private int emotion;  // 1~5 사이의 숫자로 감정 저장
+    private Integer emotion;  // 1~5 사이의 숫자로 감정 저장
 
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
     @Column(name = "chat_available", nullable = false)
-    private boolean chatAvailable = true;
+    private Boolean chatAvailable = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public Diary(String content, int emotion, LocalDate date, boolean chatAvailable, User user) {
+    public Diary(String content, Integer emotion, LocalDate date, Boolean chatAvailable, User user) {
         this.content = content;
         this.emotion = emotion;
         this.date = date;

--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -1,0 +1,44 @@
+package com.konkuk.strhat.diary.entity;
+
+import com.konkuk.strhat.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "diary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_id", updatable = false)
+    private Long id;
+
+    @Column(name = "content", length = 1500, nullable = false)
+    private String content;
+
+    @Column(name = "emotion", nullable = false)
+    private int emotion;  // 1~5 사이의 숫자로 감정 저장
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "chat_available", nullable = false)
+    private boolean chatAvailable = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Diary(String content, int emotion, LocalDate date, boolean chatAvailable, User user) {
+        this.content = content;
+        this.emotion = emotion;
+        this.date = date;
+        this.chatAvailable = chatAvailable;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/global/entity/BaseCreatedEntity.java
+++ b/src/main/java/com/konkuk/strhat/global/entity/BaseCreatedEntity.java
@@ -1,0 +1,22 @@
+package com.konkuk.strhat.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreatedEntity {
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/konkuk/strhat/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/konkuk/strhat/global/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.konkuk.strhat.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -18,7 +18,7 @@ public class SelfDiagnosis extends BaseCreatedEntity {
     private Long id;
 
     @Column(name = "score", nullable = false)
-    private int score;
+    private Integer score;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", length = 10, nullable = false)
@@ -29,7 +29,7 @@ public class SelfDiagnosis extends BaseCreatedEntity {
     private User user;
 
     @Builder
-    public SelfDiagnosis(int score, SelfDiagnosisType type, User user) {
+    public SelfDiagnosis(Integer score, SelfDiagnosisType type, User user) {
         this.score = score;
         this.type = type;
         this.user = user;

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -1,0 +1,37 @@
+package com.konkuk.strhat.self_diagnosis.entity;
+
+import com.konkuk.strhat.global.entity.BaseCreatedEntity;
+import com.konkuk.strhat.self_diagnosis.enums.SelfDiagnosisType;
+import com.konkuk.strhat.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "self_diagnosis")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SelfDiagnosis extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "self_diagnosis_id", updatable = false)
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 10, nullable = false)
+    private SelfDiagnosisType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public SelfDiagnosis(int score, SelfDiagnosisType type, User user) {
+        this.score = score;
+        this.type = type;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/enums/SelfDiagnosisType.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/enums/SelfDiagnosisType.java
@@ -1,0 +1,14 @@
+package com.konkuk.strhat.self_diagnosis.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SelfDiagnosisType {
+    PSS("Perceived Stress Scale"),  // 지각된 스트레스 척도
+    SRI("Stress Response Inventory"), // 스트레스 반응 척도
+    PHQ9("Patient Health Questionnaire-9"); // 우울증 선별 도구
+
+    private final String description;
+}

--- a/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
+++ b/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Table(name = "stress_summary")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StressSummary extends BaseCreatedEntity {
+public class StressSummary {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
+++ b/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
@@ -1,0 +1,41 @@
+package com.konkuk.strhat.stress_summary.entity;
+
+import com.konkuk.strhat.user.entity.User;
+import com.konkuk.strhat.global.entity.BaseCreatedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "stress_summary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StressSummary extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stress_summary_id", updatable = false)
+    private Long id;
+
+    @Column(name = "content", length = 255, nullable = false)
+    private String content;
+
+    @Column(name = "week_start_date", nullable = false)
+    private LocalDate weekStartDate;
+
+    @Column(name = "week_end_date", nullable = false)
+    private LocalDate weekEndDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public StressSummary(String content, LocalDate weekStartDate, LocalDate weekEndDate, User user) {
+        this.content = content;
+        this.weekStartDate = weekStartDate;
+        this.weekEndDate = weekEndDate;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -1,0 +1,62 @@
+package com.konkuk.strhat.user.entity;
+
+import com.konkuk.strhat.global.entity.BaseCreatedEntity;
+import com.konkuk.strhat.user.enums.Gender;
+import com.konkuk.strhat.user.enums.Job;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import java.time.LocalDate;
+
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", updatable = false)
+    private Long id;
+
+    @Size(max = 10, message = "닉네임은 10자 이하로 입력해주세요.")
+    @Column(name = "nickname", length = 10, nullable = false)
+    private String nickname;
+
+    @Column(name = "birth", nullable = false)
+    private LocalDate birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", length = 10, nullable = false)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job", length = 10, nullable = false)
+    private Job job;
+
+    @Size(max = 1000, message = "취미 및 힐링방법은 1000자 이하로 입력해주세요.")
+    @Column(name = "hobby_healing_style", length = 1000, nullable = false)
+    private String hobbyHealingStyle;
+
+    @Size(max = 1000, message = "스트레스 해소 방법은 1000자 이하로 입력해주세요.")
+    @Column(name = "stress_relief_style", length = 1000, nullable = false)
+    private String stressReliefStyle;
+
+    @Size(max = 1000, message = "성향 정보는 1000자 이하로 입력해주세요.")
+    @Column(name = "personality", length = 1000, nullable = false)
+    private String personality;
+
+    @Builder
+    public User(String nickname, LocalDate birth, Gender gender, Job job,
+                String hobbyHealingStyle, String stressReliefStyle, String personality) {
+        this.nickname = nickname;
+        this.birth = birth;
+        this.gender = gender;
+        this.job = job;
+        this.hobbyHealingStyle = hobbyHealingStyle;
+        this.stressReliefStyle = stressReliefStyle;
+        this.personality = personality;
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 
 @Entity
-@Table(name = "users")
+@Table(name = "user")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseCreatedEntity {

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -1,12 +1,15 @@
 package com.konkuk.strhat.user.entity;
 
 import com.konkuk.strhat.global.entity.BaseCreatedEntity;
+import com.konkuk.strhat.self_diagnosis.entity.SelfDiagnosis;
 import com.konkuk.strhat.user.enums.Gender;
 import com.konkuk.strhat.user.enums.Job;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -47,6 +50,9 @@ public class User extends BaseCreatedEntity {
     @Column(name = "personality", length = 1000, nullable = false)
     private String personality;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SelfDiagnosis> selfDiagnoses = new ArrayList<>();
+
     @Builder
     public User(String nickname, LocalDate birth, Gender gender, Job job,
                 String hobbyHealingStyle, String stressReliefStyle, String personality) {
@@ -57,6 +63,7 @@ public class User extends BaseCreatedEntity {
         this.hobbyHealingStyle = hobbyHealingStyle;
         this.stressReliefStyle = stressReliefStyle;
         this.personality = personality;
+        this.selfDiagnoses = new ArrayList<>();
     }
 
 }

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -3,6 +3,7 @@ package com.konkuk.strhat.user.entity;
 import com.konkuk.strhat.diary.entity.Diary;
 import com.konkuk.strhat.global.entity.BaseCreatedEntity;
 import com.konkuk.strhat.self_diagnosis.entity.SelfDiagnosis;
+import com.konkuk.strhat.stress_summary.entity.StressSummary;
 import com.konkuk.strhat.user.enums.Gender;
 import com.konkuk.strhat.user.enums.Job;
 import jakarta.persistence.*;
@@ -57,6 +58,10 @@ public class User extends BaseCreatedEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Diary> diaries = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StressSummary> stressSummaries = new ArrayList<>();
+
+
     @Builder
     public User(String nickname, LocalDate birth, Gender gender, Job job,
                 String hobbyHealingStyle, String stressReliefStyle, String personality) {
@@ -69,6 +74,7 @@ public class User extends BaseCreatedEntity {
         this.personality = personality;
         this.selfDiagnoses = new ArrayList<>();
         this.diaries = new ArrayList<>();
+        this.stressSummaries = new ArrayList<>();
     }
 
 }

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.user.entity;
 
+import com.konkuk.strhat.diary.entity.Diary;
 import com.konkuk.strhat.global.entity.BaseCreatedEntity;
 import com.konkuk.strhat.self_diagnosis.entity.SelfDiagnosis;
 import com.konkuk.strhat.user.enums.Gender;
@@ -53,6 +54,9 @@ public class User extends BaseCreatedEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SelfDiagnosis> selfDiagnoses = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Diary> diaries = new ArrayList<>();
+
     @Builder
     public User(String nickname, LocalDate birth, Gender gender, Job job,
                 String hobbyHealingStyle, String stressReliefStyle, String personality) {
@@ -64,6 +68,7 @@ public class User extends BaseCreatedEntity {
         this.stressReliefStyle = stressReliefStyle;
         this.personality = personality;
         this.selfDiagnoses = new ArrayList<>();
+        this.diaries = new ArrayList<>();
     }
 
 }

--- a/src/main/java/com/konkuk/strhat/user/enums/Gender.java
+++ b/src/main/java/com/konkuk/strhat/user/enums/Gender.java
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.user.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+    MALE("남자"),
+    FEMALE("여자");
+
+    private final String description;
+
+    Gender(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/user/enums/Gender.java
+++ b/src/main/java/com/konkuk/strhat/user/enums/Gender.java
@@ -1,15 +1,13 @@
 package com.konkuk.strhat.user.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum Gender {
     MALE("남자"),
     FEMALE("여자");
 
     private final String description;
-
-    Gender(String description) {
-        this.description = description;
-    }
 }

--- a/src/main/java/com/konkuk/strhat/user/enums/Job.java
+++ b/src/main/java/com/konkuk/strhat/user/enums/Job.java
@@ -1,0 +1,16 @@
+package com.konkuk.strhat.user.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Job {
+    STUDENT("대학생"),
+    EMPLOYEE("직장인"),
+    JOB_SEEKER("취준생");
+
+    private final String description;
+
+    Job(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/user/enums/Job.java
+++ b/src/main/java/com/konkuk/strhat/user/enums/Job.java
@@ -1,16 +1,14 @@
 package com.konkuk.strhat.user.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum Job {
     STUDENT("대학생"),
     EMPLOYEE("직장인"),
     JOB_SEEKER("취준생");
 
     private final String description;
-
-    Job(String description) {
-        this.description = description;
-    }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
#3

### ⛳ 작업 분류
- [x] 회원(Member) 엔티티 구현 (허은정)
- [x] 자가진단(SelfDiagnosis) 엔티티 구현 (허은정)
- [x] 스트레스 요약(StressSummary) 엔티티 구현 (허은정)
- [x] 일기(Diary) 엔티티 구현 (허은정)
- [ ] 피드백(Feedback) 엔티티 구현 (정유혁)
- [ ] 채팅내역(ChatHistory) 엔티티 구현 (정유혁)
- [ ] 스트레스 점수(StressScore) 엔티티 구현 (정유혁)

### 🔨 작업 상세 내용
1. `User` 엔티티와 나머지 엔티티 간 양방향 연관관계 설정
   - `User ↔ Diary` 
   - `User ↔ Feedback`
   - `User ↔ StressSummary`
2. 연관관계 메서드는 2/23까지 추가 예정

### 💡 생각해볼 문제
- 추후 소셜 로그인 관련 기능 구현 시, User에 필드 추가가 필요해보입니다.