### PR TITLE
[FEAT] 연관관계 메서드 추가

### DIFF
--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -29,16 +29,16 @@ public class Diary {
     @Column(name = "chat_available", nullable = false)
     private Boolean chatAvailable = true;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public Diary(String content, Integer emotion, LocalDate date, Boolean chatAvailable, User user) {
+    public Diary(String content, Integer emotion, LocalDate date, Boolean chatAvailable) {
         this.content = content;
         this.emotion = emotion;
         this.date = date;
         this.chatAvailable = chatAvailable;
-        this.user = user;
     }
 }

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -24,14 +24,14 @@ public class SelfDiagnosis extends BaseCreatedEntity {
     @Column(name = "type", length = 10, nullable = false)
     private SelfDiagnosisType type;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public SelfDiagnosis(Integer score, SelfDiagnosisType type, User user) {
+    public SelfDiagnosis(Integer score, SelfDiagnosisType type) {
         this.score = score;
         this.type = type;
-        this.user = user;
     }
 }

--- a/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
+++ b/src/main/java/com/konkuk/strhat/stress_summary/entity/StressSummary.java
@@ -27,15 +27,15 @@ public class StressSummary {
     @Column(name = "week_end_date", nullable = false)
     private LocalDate weekEndDate;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public StressSummary(String content, LocalDate weekStartDate, LocalDate weekEndDate, User user) {
+    public StressSummary(String content, LocalDate weekStartDate, LocalDate weekEndDate) {
         this.content = content;
         this.weekStartDate = weekStartDate;
         this.weekEndDate = weekEndDate;
-        this.user = user;
     }
 }

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -77,4 +77,19 @@ public class User extends BaseCreatedEntity {
         this.stressSummaries = new ArrayList<>();
     }
 
+    // 연관관계 편의 메서드
+    public void addSelfDiagnosis(SelfDiagnosis selfDiagnosis) {
+        selfDiagnoses.add(selfDiagnosis);
+        selfDiagnosis.setUser(this);
+    }
+
+    public void addDiary(Diary diary) {
+        diaries.add(diary);
+        diary.setUser(this);
+    }
+
+    public void addStressSummary(StressSummary stressSummary) {
+        stressSummaries.add(stressSummary);
+        stressSummary.setUser(this);
+    }
 }


### PR DESCRIPTION
## ✏️ 이슈 번호
- #3
</br>

## ⛳ 작업 분류
- [x] User ↔ Diary 연관관계 메서드 추가
- [x] User ↔ Feedback 연관관계 메서드 추가
- [x] User ↔ StressSummary 연관관계 메서드 추가
</br>

## 🔨 작업 상세 내용
1. `User` 엔티티에 연관관계 편의 메서드 추가  
   - `addSelfDiagnosis(SelfDiagnosis selfDiagnosis)`  
   - `addDiary(Diary diary)`  
   - `addStressSummary(StressSummary stressSummary)`  

2. `SelfDiagnosis`, `Diary`, `StressSummary`의 생성자에서 `User` 설정을 제거  
   - 객체 생성과 연관관계 설정을 분리하여 `User`에서 관계를 일괄 관리하도록 변경  
</br>


## 📍 참고 사항 (연관관계 메서드 적용 방식)

연관관계를 설정하는 방식에 대해 두 가지 방법을 고려했습니다.  

#### 1. 생성자에서 연관관계 설정
처음에는 각 엔티티(`SelfDiagnosis`, `Diary`, `StressSummary`)의 생성자에서 `User`와의 관계를 설정하는 방식을 생각했습니다.  

> 생성자
> ```java
> @Builder
> public SelfDiagnosis(Integer score, SelfDiagnosisType type, User user) {
>     this.score = score;
>     this.type = type;
>     this.user = user;
>     user.addSelfDiagnosis(this); // 연관관계 설정
> }
> ```

> 사용 예시  
> ```java
> User user = new User("닉네임", LocalDate.of(1995, 5, 20), Gender.MALE, Job.ENGINEER, "독서", "운동", "내향적");
> 
> SelfDiagnosis diagnosis = SelfDiagnosis.builder()
>     .score(85)
>     .type(SelfDiagnosisType.SRI)
>     .user(user)  // 반드시 user를 넘겨야 함
>     .build();
>
> selfDiagnosisRepository.save(diagnosis);  // ⭕ 정상 저장
> ```

- 장점  
  - 객체 생성 시점에 연관관계를 자동으로 설정할 수 있어 실수를 방지할 수 있음  

- 단점  
  - 객체만 생성하고자 할 때에도 `User`가 필수적으로 필요함 → `SelfDiagnosis`를 독립적으로 생성할 수 없음.
  - 비즈니스 로직과 연관관계 설정이 강하게 결합됨 → 유지보수가 어렵고, 유연성이 제한됨.


#### 2. `User`에서 연관관계 관리 (선택한 방식)

위 방식의 단점을 해결하기 위해, 연관관계 설정을 생성자가 아닌 `User`에서 관리하도록 했습니다.  

> User 클래스 내의 연관관계 메서드
> ```java
> public void addSelfDiagnosis(SelfDiagnosis selfDiagnosis) {
>         selfDiagnoses.add(selfDiagnosis);
>         selfDiagnosis.setUser(this);
>     }
> ```

> 사용 예시  
> ```java
> User user = new User("닉네임", LocalDate.of(1995, 5, 20), Gender.MALE, Job.ENGINEER, "독서", "운동", "내향적");
> 
> SelfDiagnosis diagnosis = SelfDiagnosis.builder()
>     .score(85)
>     .type(SelfDiagnosisType.SRI)
>     .build();  // User 없이도 생성 가능
> 
> // selfDiagnosisRepository.save(diagnosis);  // ❌ ERROR: user_id가 NULL이므로 저장 불가
> 
> user.addSelfDiagnosis(diagnosis);  // 연관관계 설정
> 
> selfDiagnosisRepository.save(diagnosis);  // ⭕ 정상 저장
> ```

- 장점  
  - 객체의 독립성 유지 → `SelfDiagnosis`를 `User` 없이도 생성 가능  
  - 연관관계 설정을 한 곳에서만 관리 → `User`에서만 관계를 설정하여 유지보수성 향상  
  - 비즈니스 로직과 객체 관계 설정을 분리 → 코드의 명확성 증가  

- 단점
  - 객체를 생성한 후 관계 설정을 따로 호출해야 하므로, 개발자가 관계 설정을 신경 써야 하는 부담이 있음


#### 🔎 결론 
두 가지 방식을 고려한 결과, 객체의 독립성을 유지하고 연관관계 관리를 일관되게 할 수 있는 후자의 방식을 선택했습니다.  
객체 생성 후, 연관관계 메서드를 호출해준 뒤에, save 해주는 것만 신경쓰면 될 것 같습니다.