### PR TITLE
[FEAT] Feedback, StreesScore, ChatMessage 엔티티 구현

### DIFF
--- a/src/main/java/com/konkuk/strhat/chat/entity/ChatMessage.java
+++ b/src/main/java/com/konkuk/strhat/chat/entity/ChatMessage.java
@@ -13,7 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/konkuk/strhat/chat/entity/ChatMessage.java
+++ b/src/main/java/com/konkuk/strhat/chat/entity/ChatMessage.java
@@ -1,0 +1,51 @@
+package com.konkuk.strhat.chat.entity;
+
+import com.konkuk.strhat.chat.enums.Sender;
+import com.konkuk.strhat.diary.entity.Diary;
+import com.konkuk.strhat.global.entity.BaseCreatedEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_message_id", updatable = false)
+    private Long id;
+
+    @Column(name = "content", length = 255, nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender", length = 255, nullable = false)
+    private Sender sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Builder
+    public ChatMessage(String content, Sender sender, Diary diary) {
+        this.content = content;
+        this.sender = sender;
+        this.diary = diary;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/chat/enums/Sender.java
+++ b/src/main/java/com/konkuk/strhat/chat/enums/Sender.java
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.chat.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Sender {
+    USER("유저"),
+    CHAT_BOT("챗봇");
+
+    private final String description;
+}

--- a/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
@@ -1,0 +1,63 @@
+package com.konkuk.strhat.diary.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "feedback")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Feedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feedback_id", updatable = false)
+    private Long id;
+
+    @Column(name = "diary_summary",length = 255, nullable = false)
+    private String diarySummary;
+
+    @Column(name = "positive_emotions",length = 255, nullable = false)
+    private String positiveEmotions;
+
+    @Column(name = "negative_emotions",length = 255, nullable = false)
+    private String negativeEmotions;
+
+    @Column(name = "stress_relief_suggestion",length = 255, nullable = false)
+    private String stressReliefSuggestion;
+
+    @Column(name = "feedback_date", nullable = false)
+    private LocalDate feedbackDate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Builder
+    public Feedback(String diarySummary,
+                    String positiveEmotions,
+                    String negativeEmotions,
+                    String stressReliefSuggestion,
+                    LocalDate feedbackDate,
+                    Diary diary) {
+        this.diarySummary = diarySummary;
+        this.positiveEmotions = positiveEmotions;
+        this.negativeEmotions = negativeEmotions;
+        this.stressReliefSuggestion = stressReliefSuggestion;
+        this.feedbackDate = feedbackDate;
+        this.diary = diary;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
@@ -52,7 +52,8 @@ public class Feedback {
                     String negativeEmotions,
                     String stressReliefSuggestion,
                     LocalDate feedbackDate,
-                    Diary diary) {
+                    Diary diary
+    ) {
         this.diarySummary = diarySummary;
         this.positiveEmotions = positiveEmotions;
         this.negativeEmotions = negativeEmotions;

--- a/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
@@ -44,7 +44,8 @@ public class StressScore {
     public StressScore(Integer score,
                        String stressFactor,
                        LocalDate recordedDate,
-                       Diary diary) {
+                       Diary diary
+    ) {
         this.score = score;
         this.stressFactor = stressFactor;
         this.recordedDate = recordedDate;

--- a/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
@@ -1,0 +1,53 @@
+package com.konkuk.strhat.diary.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "stress_score")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StressScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stress_score_id", updatable = false)
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    @Column(name = "stress_factor", length = 255, nullable = false)
+    private String stressFactor;
+
+    @Column(name = "recorded_date", nullable = false)
+    private LocalDate recordedDate;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Builder
+    public StressScore(Integer score,
+                       String stressFactor,
+                       LocalDate recordedDate,
+                       Diary diary) {
+        this.score = score;
+        this.stressFactor = stressFactor;
+        this.recordedDate = recordedDate;
+        this.diary = diary;
+    }
+}


### PR DESCRIPTION
### ✏️ 이슈 번호
- #3 

### ⛳ 작업 분류
- [x] 작업1 Feedback 엔티티 구현
- [x] 작업2 StressScore 엔티티 구현
- [x] 작업3 ChatMessage 엔티티 구현

### 🔨 작업 상세 내용
1. 각 엔티티를 구현하였고, ChatMessage의 경우 유저 혹은 챗봇 두 개의 Sender만 존재하므로 ENUM으로 관리하고자 합니다.

### 💡 생각해볼 문제
- 이전에 한번 논의했던 내용인데, Spring validation 어노테이션을 사용하는 것에 관련하여 찾아보았는데, 엔티티 계층에서 Validation 어노테이션을 사용하는 것은 찾지 못하였으며, 대부분의 경우 DTO에서 해당 어노테이션을 사용하는 것을 알게 되었습니다. 저도 DTO 에서 Validation 어노테이션을 사용하는게 조금 더 옳다고 생각하며 그 이유는 아래와 같습니다.

1. 유효성 검증의 주 목적은 클라이언트가 전달하는 데이터의 올바른 형식을 확인하는 것입니다.
DTO는 클라이언트와 서버 간 데이터 전달을 위한 객체이므로, 클라이언트가 보내온 데이터가 올바른지 검사하는 역할을 DTO에 두는 것이 가장 자연스럽고 직관적입니다.

2. 엔티티 계층은 주로 데이터베이스와의 매핑 및 비즈니스 로직을 담당합니다.
엔티티에 추가적인 검증 로직을 넣게 되면, DB 제약조건 외에도 다양한 검증 책임이 섞이게 되어 역할이 모호해지고, 코드의 응집도 및 유지보수성이 떨어질 수 있습니다.

위와 같은 이유로 우선은 구현한 엔티티에서 Validation은 사용하지 않았는데, 의견이 궁금합니다!

- 긍정, 부정 감정 키워드가 어떤 형식으로 GPT에서 넘어오는지 모르겠어서 우선 ERD에 있는 대로 String으로 설정해뒀는데, 수정해야 할 것 같으면 말씀해주세용

- Sender에서 챗봇이라고 해놨는데, 좀 애매해서 AI로 바꾸는게 나을 것 같기도 하네요..

[Spring Boot Validation 참고 링크](https://adjh54.tistory.com/77)
