### PR TITLE
[FIX] 엔티티 수정

### DIFF
--- a/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
@@ -33,8 +33,8 @@ public class StressScore {
     @Column(name = "stress_factor", length = 255, nullable = false)
     private String stressFactor;
 
-    @Column(name = "recorded_date", nullable = false)
-    private LocalDate recordedDate;
+    @Column(name = "stress_score_date", nullable = false)
+    private LocalDate stressScoreDate;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", nullable = false)
@@ -43,12 +43,12 @@ public class StressScore {
     @Builder
     public StressScore(Integer score,
                        String stressFactor,
-                       LocalDate recordedDate,
+                       LocalDate stressScoreDate,
                        Diary diary
     ) {
         this.score = score;
         this.stressFactor = stressFactor;
-        this.recordedDate = recordedDate;
+        this.stressScoreDate = stressScoreDate;
         this.diary = diary;
     }
 }

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -1,16 +1,16 @@
 package com.konkuk.strhat.self_diagnosis.entity;
 
-import com.konkuk.strhat.global.entity.BaseCreatedEntity;
 import com.konkuk.strhat.self_diagnosis.enums.SelfDiagnosisType;
 import com.konkuk.strhat.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "self_diagnosis")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SelfDiagnosis extends BaseCreatedEntity {
+public class SelfDiagnosis {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,14 +24,18 @@ public class SelfDiagnosis extends BaseCreatedEntity {
     @Column(name = "type", length = 10, nullable = false)
     private SelfDiagnosisType type;
 
+    @Column(name = "self_diagnosis_date", nullable = false)
+    private LocalDate selfDiagnosisDate;
+
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public SelfDiagnosis(Integer score, SelfDiagnosisType type) {
+    public SelfDiagnosis(Integer score, SelfDiagnosisType type, LocalDate selfDiagnosisDate) {
         this.score = score;
         this.type = type;
+        this.selfDiagnosisDate = selfDiagnosisDate;
     }
 }

--- a/src/main/java/com/konkuk/strhat/user/entity/User.java
+++ b/src/main/java/com/konkuk/strhat/user/entity/User.java
@@ -25,7 +25,6 @@ public class User extends BaseCreatedEntity {
     @Column(name = "user_id", updatable = false)
     private Long id;
 
-    @Size(max = 10, message = "닉네임은 10자 이하로 입력해주세요.")
     @Column(name = "nickname", length = 10, nullable = false)
     private String nickname;
 
@@ -40,15 +39,12 @@ public class User extends BaseCreatedEntity {
     @Column(name = "job", length = 10, nullable = false)
     private Job job;
 
-    @Size(max = 1000, message = "취미 및 힐링방법은 1000자 이하로 입력해주세요.")
     @Column(name = "hobby_healing_style", length = 1000, nullable = false)
     private String hobbyHealingStyle;
 
-    @Size(max = 1000, message = "스트레스 해소 방법은 1000자 이하로 입력해주세요.")
     @Column(name = "stress_relief_style", length = 1000, nullable = false)
     private String stressReliefStyle;
 
-    @Size(max = 1000, message = "성향 정보는 1000자 이하로 입력해주세요.")
     @Column(name = "personality", length = 1000, nullable = false)
     private String personality;
 


### PR DESCRIPTION
### ✏️ 이슈 번호
- #10 

### ⛳ 작업 분류
- [x] 작업1 StressScore 필드명 변경
- [x] 작업2 자가진단 검사일 LocalDate 변경
- [x] 작업3 User 엔티티 Validation 어노테이션 제거

### 🔨 작업 상세 내용
1. StressScore를 제외한 모든 테이블에서 테이블 명 뒤에 date를 붙이는 방식을 사용하여 필드명을 변경하였습니다.
