### PR TITLE
[FIX] 엔티티 수정 마무리

### DIFF
--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -21,7 +21,7 @@ public class Diary {
     private String content;
 
     @Column(name = "emotion", nullable = false)
-    private Integer emotion;  // 1~5 사이의 숫자로 감정 저장
+    private Integer emotion;
 
     @Column(name = "diary_date", nullable = false)
     private LocalDate diaryDate;

--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -26,19 +26,15 @@ public class Diary {
     @Column(name = "diary_date", nullable = false)
     private LocalDate diaryDate;
 
-    @Column(name = "chat_available", nullable = false)
-    private Boolean chatAvailable = true;
-
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public Diary(String content, Integer emotion, LocalDate diaryDate, Boolean chatAvailable) {
+    public Diary(String content, Integer emotion, LocalDate diaryDate) {
         this.content = content;
         this.emotion = emotion;
         this.diaryDate = diaryDate;
-        this.chatAvailable = chatAvailable;
     }
 }

--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -23,8 +23,8 @@ public class Diary {
     @Column(name = "emotion", nullable = false)
     private Integer emotion;  // 1~5 사이의 숫자로 감정 저장
 
-    @Column(name = "date", nullable = false)
-    private LocalDate date;
+    @Column(name = "diary_date", nullable = false)
+    private LocalDate diaryDate;
 
     @Column(name = "chat_available", nullable = false)
     private Boolean chatAvailable = true;
@@ -35,10 +35,10 @@ public class Diary {
     private User user;
 
     @Builder
-    public Diary(String content, Integer emotion, LocalDate date, Boolean chatAvailable) {
+    public Diary(String content, Integer emotion, LocalDate diaryDate, Boolean chatAvailable) {
         this.content = content;
         this.emotion = emotion;
-        this.date = date;
+        this.diaryDate = diaryDate;
         this.chatAvailable = chatAvailable;
     }
 }

--- a/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Diary.java
@@ -23,7 +23,7 @@ public class Diary {
     @Column(name = "emotion", nullable = false)
     private Integer emotion;
 
-    @Column(name = "diary_date", nullable = false)
+    @Column(name = "diary_date", nullable = false, unique = true)
     private LocalDate diaryDate;
 
     @Setter

--- a/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/Feedback.java
@@ -39,7 +39,7 @@ public class Feedback {
     @Column(name = "stress_relief_suggestion",length = 255, nullable = false)
     private String stressReliefSuggestion;
 
-    @Column(name = "feedback_date", nullable = false)
+    @Column(name = "feedback_date", nullable = false, unique = true)
     private LocalDate feedbackDate;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
+++ b/src/main/java/com/konkuk/strhat/diary/entity/StressScore.java
@@ -33,7 +33,7 @@ public class StressScore {
     @Column(name = "stress_factor", length = 255, nullable = false)
     private String stressFactor;
 
-    @Column(name = "stress_score_date", nullable = false)
+    @Column(name = "stress_score_date", nullable = false, unique = true)
     private LocalDate stressScoreDate;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -24,7 +24,7 @@ public class SelfDiagnosis {
     @Column(name = "type", length = 10, nullable = false)
     private SelfDiagnosisType type;
 
-    @Column(name = "self_diagnosis_date", nullable = false)
+    @Column(name = "self_diagnosis_date", nullable = false, unique = true)
     private LocalDate selfDiagnosisDate;
 
     @Setter
@@ -33,7 +33,7 @@ public class SelfDiagnosis {
     private User user;
 
     @Builder
-    public SelfDiagnosis(Integer score, SelfDiagnosisType type, LocalDate selfDiagnosisDate) {
+    public SelfDiagnosis(Integer score, SelfDiagnosisType type) {
         this.score = score;
         this.type = type;
         this.selfDiagnosisDate = LocalDate.now();

--- a/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/self_diagnosis/entity/SelfDiagnosis.java
@@ -36,6 +36,6 @@ public class SelfDiagnosis {
     public SelfDiagnosis(Integer score, SelfDiagnosisType type, LocalDate selfDiagnosisDate) {
         this.score = score;
         this.type = type;
-        this.selfDiagnosisDate = selfDiagnosisDate;
+        this.selfDiagnosisDate = LocalDate.now();
     }
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
- #10

### ⛳ 작업 분류
- [x] 불필요한 필드 삭제 & 주석 제거
- [x] 엔티티 내 필드에 유니크 제약 조건 추가
- [x] Diary 엔티티 필드명 변경
- [x] selfDiagnosisDate 생성 시 LocalDate.now() 적용

### 🔨 작업 상세 내용
1. Diary 엔티티의 날짜 필드명을 변경하여 의미를 더 명확하게 하였습니다.
2. 엔티티별 date 필드에 유니크 제약 조건을 추가하여 데이터 무결성을 보장하도록 하였습니다.
3. 사용되지 않는 불필요한 필드를 삭제하여 코드 정리하였습니다.
4. 불필요한 주석을 제거하였습니다.
5. selfDiagnosisDate 생성 시 LocalDate.now()를 적용하여 기본값을 설정하였습니다.


### 📍참고사항
- date 관련 필드에 유니크 제약 조건을 추가함에 따라, 추후 API 기능 구현 시 중복 저장 요청에 대한 에러 핸들링을 명확하게 해주어야 할 것 같습니다!