### PR TITLE
[FIX] api response 개선

### DIFF
--- a/src/main/java/com/konkuk/strhat/global/exception/ErrorCode.java
+++ b/src/main/java/com/konkuk/strhat/global/exception/ErrorCode.java
@@ -13,9 +13,11 @@ public enum ErrorCode {
 
     // USER
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "U404", "유저가 존재하지 않습니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "U405", "허용되지 않는 메서드입니다"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U409", "이미 존재하는 이메일입니다."),
     UNSUPPORTED_GENDER_TYPE(HttpStatus.BAD_REQUEST, "U400", "지원하지 않는 성별 타입입니다."),
     UNSUPPORTED_JOB_TYPE(HttpStatus.BAD_REQUEST, "U400", "지원하지 않는 직업 타입입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "U400", "유효하지 않은 값을 입력하였습니다."),
 
     // JWT
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "J404", "토큰이 존재하지 않습니다.");

--- a/src/main/java/com/konkuk/strhat/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/konkuk/strhat/global/exception/GlobalExceptionHandler.java
@@ -2,26 +2,48 @@ package com.konkuk.strhat.global.exception;
 
 import com.konkuk.strhat.global.response.ApiResponse;
 import com.konkuk.strhat.global.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(RuntimeException.class)
-    public ApiResponse<?> handleRuntimeException(RuntimeException e) {
-        return handleException(e, ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
-    }
-
     @ExceptionHandler(CustomException.class)
-    public ApiResponse<?> handleCustomException(CustomException e) {
-        return handleException(e, ErrorResponse.from(e.getErrorCode()));
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorResponse errorResponse = ErrorResponse.from(e.getErrorCode());
+        return handleException(e, errorResponse);
     }
 
-    public ApiResponse<?> handleException(Exception e, ErrorResponse errorResponse) {
-        log.error("{}: {}", errorResponse.getCode(), e.getMessage());
-        return ApiResponse.error(errorResponse);
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        return handleException(e, errorResponse);
     }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(Exception e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, e.getMessage());
+        return handleException(e, errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getMessage());
+        return handleException(e, errorResponse);
+    }
+
+    private ResponseEntity<ErrorResponse> handleException(Exception e, ErrorResponse errorResponse) {
+        log.error("[{}] {}: {}", errorResponse.getCode(), e.getClass().getSimpleName(), e.getMessage());
+        return ResponseEntity
+                .status(errorResponse.getStatus())
+                .body(errorResponse);
+    }
+
 }

--- a/src/main/java/com/konkuk/strhat/global/response/ApiResponse.java
+++ b/src/main/java/com/konkuk/strhat/global/response/ApiResponse.java
@@ -11,31 +11,19 @@ import lombok.Getter;
 public class ApiResponse<T> {
 
     @JsonProperty(value = "isSuccess")
-    private final boolean success;
+    private final boolean success = true;
 
     @JsonProperty(value = "response")
     private final T response;
 
-    @JsonProperty(value = "error")
-    private final ErrorResponse errorResponse;
-
     public static <T> ApiResponse<T> success(T response) {
         return ApiResponse.<T>builder()
-                .success(true)
                 .response(response)
-                .build();
-    }
-
-    public static ApiResponse<?> error(ErrorResponse errorResponse) {
-        return ApiResponse.builder()
-                .success(false)
-                .errorResponse(errorResponse)
                 .build();
     }
 
     public static ApiResponse<Void> successOnly() {
         return ApiResponse.<Void>builder()
-                .success(true)
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/global/response/ErrorResponse.java
+++ b/src/main/java/com/konkuk/strhat/global/response/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.global.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.konkuk.strhat.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +8,8 @@ import lombok.Getter;
 @Builder
 @Getter
 public class ErrorResponse {
+    @JsonProperty(value = "isSuccess")
+    private final boolean success = false;
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/konkuk/strhat/global/util/SecurityUtil.java
+++ b/src/main/java/com/konkuk/strhat/global/util/SecurityUtil.java
@@ -1,0 +1,25 @@
+package com.konkuk.strhat.global.util;
+
+import com.konkuk.strhat.domain.user.entity.CustomUserDetails;
+import com.konkuk.strhat.domain.user.exception.NotFoundUserException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtil {
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new NotFoundUserException();
+        }
+
+        if (!(authentication.getPrincipal() instanceof CustomUserDetails customUserDetails)) {
+            throw new NotFoundUserException();
+        }
+
+        return customUserDetails.getId();
+    }
+}
+


### PR DESCRIPTION
### ✏️ 이슈 번호
- #19

### ⛳ 작업 분류
- [x] 실패시에 200이 아닌 실패에 관한 상태코드로 응답하도록 수정
- [x] 실패 응답 관련 코드 리팩토링 (GlobalExceptionHandler 클래스 리팩토링)
- [x] SecurityUtil 클래스 추가하여 현재 로그인한 사용자의 ID를 가져오는 유틸 메서드 구현

### 🔨 작업 상세 내용
1. ApiResponse와 ErrorResponse의 역할이 불분명했던 부분을 명확히 분리하여 응답 구조를 정리하였습니다. 
- 기존에는 성공과 실패시 모두 ApiResponse 클래스를 사용하도록 되어 있었는데, 성공/실패 response 클래스를 명확하게 따로 사용하도록 했습니다. (성공과 실패시 응답해야하는 필드가 다르기 때문에 분리하는 것이 좋다고 생각했습니다. 가장 크게 다른 점은, 실패 시 `private final T response`가 필요없습니다.)
- ApiResponse는 성공 응답 전용으로 사용하고, 내부 success=true을 기본값으로 적용했습니다.
- ErrorResponse는 실패 응답 전용으로 사용하고, 내부 success=false를 기본값으로 적용했습니다. 
2. GlobalExceptionHandler 클래스를 리팩토링하여 handleException(Exception, ErrorResponse) 메서드가 ResponseEntity<ErrorResponse>를 직접 반환하도록 변경하였습니다.
- 기존 handleException()이라는 공통 메서드는 반환 타입이 ApiResponse<?>였고 내부적으로 오류가 나더라도 항상 HTTP 200 OK로 응답되는 구조였습니다. 이로 인해 실제 예외 상황임에도 클라이언트에서는 실제 HTTP 상태코드는 200으로 받고, 내부 응답 필드를 통해서만 오류 상태코드를 감지할 수 있떤 문제가 있었습니다.
- 이에 따라, handleException(Exception, ErrorResponse) 메서드가 ResponseEntity<ErrorResponse>를 직접 반환하도록 변경하였고, 내부에서 errorResponse.getStatus() 값을 .status()에 그대로 반영함으로써 HTTP 응답 코드가 400, 403, 501 등 실제 예외에 맞는 상태 코드로 클라이언트에 전달되도록 하였습니다.
3. 응답 에러를 세분화하고 명확히 하기 위해 다음 항목을 추가하고, ErrorCode와 GlobalExceptionHandler에 추가해주었습니다.
- `METHOD_NOT_ALLOWED`
- `INVALID_INPUT_VALUE`
4. 추가로, 현재 로그인한 사용자의 ID를 가져오는 SecurityUtil.getCurrentUserId() 유틸 메서드도 구현하였습니다.
- Spring Security의 SecurityContextHolder에서 인증 정보를 추출하여 사용자 ID 반환하고, 인증 정보가 없거나 사용자 정보가 CustomUserDetails가 아닌 경우 NotFoundUserException 예외를 발생시키도록 했습니다.
- @NoArgsConstructor(access = AccessLevel.PRIVATE)로 인스턴스화를 방지하였습니다. (이 클래스에는 전부 static 메서드만 선언할 예정이라 SecurityUtil을 굳이 인스턴스화할 필요가 없습니다. 때문에, 실수로 객체를 만들지 않도록 아예 생성자를 private으로 막아서 이 클래스는 외부에서 인스턴스화할 수 없게 하였습니다.)


### 💡 생각해볼 문제
- 현재 Filter를 거치는 Security 관련 응답커스텀은 구현되지 않은 상태라서, 추가로 구현이 필요합니다.
- 에러 핸들링 시, `EntityNotFoundException.class`, `Exception.class` 등에 대해서도 추가할 수 있습니다. 
- 추가로, 이번 변경사항과 관련된 내용을 정리해보았는데, 읽어보시면 좋을 것 같습니다.

<details>
<summary> 실패의 경우에도 무조건 200으로만 응답하는 것이 잘못된 이유 </summary>
<div>
저는 지금까지 개발할 때, 항상 에러코드로 정의한 상태코드와 실제 HTTP 상태 코드와 동일하게 응답하도록 개발을 해왔습니다. 
그래서 실패의 경우에도 응답을 무조건 200으로 지정하신 방법에 대한 의문이 있어 따로 알아보았습니다.
아주 일부 기업에서는 보안을 위해 모든 API 를 200으로 응답하는 경우가 있긴 하다고 합니다.
그러나, 상태 코드 200은 요청이 성공적으로 완료되었다는 메세지를 전달하는 기능을 갖고 있습니다.
때문에 실패의 경우에도 모든 요청을 200으로 처리한다는 것은 통신 규약 상 적절하지 않다고 생각합니다.
HTTP 상태 코드는 클라이언트와 서버 간의 통신에서 기본적인 규약입니다.  
실효성이 크지 않은 보안상의 이유로 이를 무시하는 경우, 그에 따른 단점이 훨씬 많다고 생각합니다. (단점 - HTTP 상태 코드만으로 분기 처리할 수 있는데, 항상 200일 경우 response body를 파싱하고 추가 로직을 넣어야 하기 때문에, 클라이언트의 예외 처리가 어려워질 수 있고, 상태코드를 기준으로 에러를 감지하는 모니터링 시스템(AWS CloudWatch 등) 또한 처리가 복잡해짐. 사용중인 Swagger에서 응답을 상태 코드별로 구분할 수 없어, 문서화의 의미가 떨어지고 오히려 혼동을 줄 수 있음. 등)
관련 글을 남깁니다.

[글1](https://jaeseongdev.github.io/development/2021/04/22/REST_API%EC%97%90%EC%84%9C%EC%9D%98_HTTP_%EC%83%81%ED%83%9C%EC%BD%94%EB%93%9C_%EC%83%81%ED%83%9C%EB%A9%94%EC%8B%9C%EC%A7%80.md/)

> [글1 내 일부 내용 추출]
> 아래 설계는 무조건 잘못된 것이니 수정하자!
> 
> HTTP/1.1 200 OK
> {
>     "result" : false
>     "status" : 400
> }
> 상태 코드는 200으로 성공인데, body 내용엔 실패에 관한 내용을 리턴하고 있다.
> 모든 응답을 200으로 처리하고 body 내용으로 성공 및 실패를 판단하는 구조에서 사용된다.
> → API가 아닌 HTML 웹 프로젝트에서 대부분 이렇게 사용한다.
> → 웹 프로젝트에선 크게 문제가 되지 않으나 API에선 많이 이상한 구조다.
> → 웹의 설계를 그대로 사용하는 경우 많이 하는 실수다.

[글2](https://okky.kr/questions/661303)
> 질문글)
> 백엔드 개발자가 HTTP STATUS 코드를 항상 200 코드를 뿌려주는데 뭐라해야할지모르겠습니다
> 
> 의견1)
> STATUS 코드는 자기 마음대로 쓰는게 아니고 엄격하게 프로토콜이 정해져 있습니다.
> Status를 200으로 고정하고 body에 오류코드를 넣는 방식은 HTTP 프로토콜을 잘못 이해하고 쓰는 것입니다.
> 
> 의견2)
> 정부 시큐어 코딩 기준이 그런걸로 알고있습니다..
> 에러 코드로 인해 공격자가 판단할수 있는 여지를 주기때문에 에러 페이지의 에러코드를 항상 200으로 고정시키라고 하더군요..
> 그럼 에러 확인과 처리는 어케 하냐는 눈으로 쳐다봤는데 잠깐 생각해보니 그건 개발자가 알아서 해결하겠지 라고 생각하며 만들었겠구나 하는 생각이 들었습니다..

[글3](https://yubi5050.tistory.com/285)
> API 설계시 일부 기업이나 방법론 중 모든 상태 코드를 200으로 처리하는 방법이 종종 거론되곤 한다.
> 일반적으로 응답 코드는 요청에 대한 상태를 나타내는 HTTP 상태 코드(Status code)와, 에러에 대한 정보를 담은 세부 에러 코드(Error code)로 나뉘며
> 일반적인 처리는 상태 코드별로 > 세부 에러 코드를 나누는 것이 일반적이다.
> 위에 말한 방법은 상태 코드를 통일하고 > 세부 에러 코드로 통합 하는 것 이다.
> 
> [모든 상태코드를 200으로 고정하여 처리 하는 경우]
> 주된 목적 : HTTP Status Code가 노출 될 시 보안에 위험이 있을 수 있음 (ex. 정부 시큐어 코딩 내용 중 공격자가 상태 코드를 통해 정보를 얻을 수 있다는 이유
> 특징 :
> 기존에 일부 상태코드를 200으로 처리 (ex. 200, 204, 400, 401, 403, 404, 500등..)
> 502, 503 일부 상태 코드에 대해서는 웹 어플리케이션 뿐 아닌, 웹 서버 레벨에서의 처리도 병행되어야 함 (ex. Nginx)
> 모든 영역 (인프라, 서버, 앱 등)에서의 처리에 보다 적절한 경우지 않을까 하는
> HTTP 프로토콜 표준에 맞지 않으며, 다양한 외부 연동시에 충돌이나 복잡도가 높아질 가능성도 있음
> 실제 사용하는 기업
> NHN : https://docs.nhncloud.com/ko/Notification/Push/ko/api-guide/
> 
> [결론]
> 상태코드를 지키며 HTTP 표준 대로 하는 방법이 제일 좋은 것 같다.
> 기본적으로는 상태코드 (200, 400, 401, 500 등 구분하고) 필요시 Header나, Body등을 통해 세부 정보를 더 보내주는 것이 낫지 않나 싶다.

</div>
</details>

<details>
<summary>기존 코드가 무조건 200으로만 응답하던 이유: ExceptionHandler로 지정한 메소드가 ApiResponse<?>를 반환하기 때문. </summary>
<div>
[기존 코드: ApiResponse<?>를 반환]

```java
// RuntimeException 처리 메서드 → handleException 호출
public ApiResponse<?> handleRuntimeException(RuntimeException e) {
    return handleException(e, ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR));
}

// handleException 메서드 정의 (공통 예외 처리 메서드)
public ApiResponse<?> handleException(Exception e, ErrorResponse errorResponse) {
    log.error("{}: {}", errorResponse.getCode(), e.getMessage());
    return ApiResponse.error(errorResponse);
}
```
위와 같은 기존 코드대로라면, 기본적으로 HTTP 응답 상태 코드는 200 OK입니다.
왜냐하면 Spring에서는 @RestController나 @ResponseBody가 붙은 메서드에서 객체를 반환하면 그 객체를 JSON으로 변환해서 응답 본문(body)에 넣어주는데, HTTP 응답 상태 코드는 개발자가 ResponseEntity.status(400)처럼 명시적으로 지정하지 않는 한 항상 기본값인 200 OK를 사용하기 때문입니다.
즉, 내부 데이터는 오류 정보를 담고 있더라도, HTTP 레벨에서는 성공 응답(200 OK) 으로 보이게 됩니다.

[지금 구조: ResponseEntity<ErrorResponse>를 반환]

```java
// RuntimeException 처리 메서드 → handleException 호출
@ExceptionHandler(MethodArgumentTypeMismatchException.class)
public ResponseEntity<ErrorResponse> handleTypeMismatchException(...) {
    ErrorResponse error = ...
    return ResponseEntity.status(error.getStatus()).body(error);
}

// handleException 메서드 정의 (공통 예외 처리 메서드)
private ResponseEntity<ErrorResponse> handleException(Exception e, ErrorResponse errorResponse) {
    log.error("[{}] {}: {}", errorResponse.getCode(), e.getClass().getSimpleName(), e.getMessage());

    return ResponseEntity
            .status(errorResponse.getStatus())
            .body(errorResponse);
}

```
이렇게 수정함으로써, 각 비즈니스 예외 상황에 대해 ResponseEntity 객체 생성 시 적절한 HTTP 상태 코드를 함께 설정함으로써, 클라이언트는 HTTP 응답 코드를 명확히 인지할 수 있게 되었습니다. Spring이 이 ResponseEntity를 그대로 직렬화하면서 클라이언트에 해당 상태 코드로 응답하게 되는 구조입니다.
(또한, `ApiResponse`는 성공시에만 사용하고, `ErrorResponse`는 실패시에만 사용하도록 변경해주었기에, `ResponseEntity<ApiResponse<?>>` 가아닌, `ResponseEntity<ErrorResponse>`로 설정해주었습니다.)
논외로, handleException 메서드는 @ExceptionHandler가 선언된 메서드 내부에서 호출되는 구조이기에, public에서 private으로 변경하여 선언해주었습니다.

정리하자면, ResponseEntity는 HTTP 응답의 전체(상태 코드, 헤더, 본문) 를 제어할 수 있는 수단입니다.
기존처럼 일반 Java 객체(ApiResponse)만 반환하면 body만 설정되고, 상태 코드는 200으로 고정됩니다.
그래서 예외 응답, 에러 처리 등에서는 반드시 ResponseEntity를 써야 올바른 상태 코드를 지정할 수 있습니다.

</div>
</details>