### PR TITLE
[FEAT] 유저 API 유효성 검증 및 예외 처리

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/user/api/OauthController.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/api/OauthController.java
@@ -6,6 +6,7 @@ import com.konkuk.strhat.domain.user.dto.PostKakaoSignInResponse;
 import com.konkuk.strhat.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +22,7 @@ public class OauthController {
 
     @Operation(summary = "카카오 검증 및 로그인", description = "카카오 계정 유무를 검증하고 로그인한다.")
     @PostMapping("/kakao")
-    public ApiResponse<PostKakaoSignInResponse> kakaoSignIn(@RequestBody PostKakaoSignInRequest request, HttpServletResponse httpServletResponse) {
+    public ApiResponse<PostKakaoSignInResponse> kakaoSignIn(@Valid @RequestBody PostKakaoSignInRequest request, HttpServletResponse httpServletResponse) {
         PostKakaoSignInResponse response = kakaoOAuthService.getUserProfileByToken(request, httpServletResponse);
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/konkuk/strhat/domain/user/api/UserController.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/api/UserController.java
@@ -9,13 +9,12 @@ import com.konkuk.strhat.domain.user.dto.PatchPersonalityRequest;
 import com.konkuk.strhat.domain.user.dto.PatchStressReliefStyleRequest;
 import com.konkuk.strhat.domain.user.dto.PostSignUpRequest;
 import com.konkuk.strhat.domain.user.dto.TokenDto;
-import com.konkuk.strhat.domain.user.entity.CustomUserDetails;
 import com.konkuk.strhat.global.response.ApiResponse;
+import com.konkuk.strhat.global.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,47 +38,43 @@ public class UserController {
 
     @Operation(summary = "로그아웃" ,description = "로그아웃한다.")
     @PostMapping("/sign-out")
-    public ApiResponse<Void> signOut(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.processSignOut(userDetails.getEmail());
+    public ApiResponse<Void> signOut() {
+        userService.processSignOut(SecurityUtil.getCurrentUserEmail());
         return ApiResponse.successOnly();
     }
 
     @Operation(summary = "유저 정보 조회", description = "유저의 정보를 조회한다.")
     @GetMapping("")
-    public ApiResponse<GetUserInfoResponse> readUserInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        GetUserInfoResponse response = userService.findUserInfo(customUserDetails.getId());
+    public ApiResponse<GetUserInfoResponse> readUserInfo() {
+        GetUserInfoResponse response = userService.findUserInfo(SecurityUtil.getCurrentUserId());
         return ApiResponse.success(response);
     }
 
     @Operation(summary = "기본 정보 변경", description = "유저의 닉네임, 태어난 년도, 성별, 직업을 변경한다.")
     @PatchMapping("/info")
-    public ApiResponse<Void> updateUserBasicInfo(@Valid @RequestBody PatchBasicInfoRequest request,
-                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.modifyUserBasicInfo(request, userDetails.getId());
+    public ApiResponse<Void> updateUserBasicInfo(@Valid @RequestBody PatchBasicInfoRequest request) {
+        userService.modifyUserBasicInfo(request, SecurityUtil.getCurrentUserId());
         return ApiResponse.successOnly();
     }
 
     @Operation(summary = "취미 및 힐링 방법 변경", description = "유저의 취미 및 힐링 방법을 변경한다.")
     @PatchMapping("/hobby-healing-style")
-    public ApiResponse<Void> updateHobbyHealingStyle(@Valid @RequestBody PatchHobbyHealingStyleRequest request,
-                                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.modifyHobbyHealingStyle(request, userDetails.getId());
+    public ApiResponse<Void> updateHobbyHealingStyle(@Valid @RequestBody PatchHobbyHealingStyleRequest request) {
+        userService.modifyHobbyHealingStyle(request, SecurityUtil.getCurrentUserId());
         return ApiResponse.successOnly();
     }
 
     @Operation(summary = "스트레스 해소 방법 변경", description = "유저의 기존 스트레스 해소 방법을 변경한다.")
     @PatchMapping("/stress-relief-style")
-    public ApiResponse<Void> updateStressReliefStyle(@Valid @RequestBody PatchStressReliefStyleRequest request,
-                                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.modifyStressReliefStyle(request, userDetails.getId());
+    public ApiResponse<Void> updateStressReliefStyle(@Valid @RequestBody PatchStressReliefStyleRequest request) {
+        userService.modifyStressReliefStyle(request, SecurityUtil.getCurrentUserId());
         return ApiResponse.successOnly();
     }
 
     @Operation(summary = "성향 변경", description = "유저의 기존 성향 정보를 변경한다.")
     @PatchMapping("/personality")
-    public ApiResponse<Void> updatePersonality(@Valid @RequestBody PatchPersonalityRequest request,
-                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.modifyPersonality(request, userDetails.getId());
+    public ApiResponse<Void> updatePersonality(@Valid @RequestBody PatchPersonalityRequest request) {
+        userService.modifyPersonality(request, SecurityUtil.getCurrentUserId());
         return ApiResponse.successOnly();
     }
 

--- a/src/main/java/com/konkuk/strhat/domain/user/api/UserController.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/api/UserController.java
@@ -13,6 +13,7 @@ import com.konkuk.strhat.domain.user.entity.CustomUserDetails;
 import com.konkuk.strhat.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,7 +32,7 @@ public class UserController {
 
     @Operation(summary = "회원가입", description = "회원가입한다.")
     @PostMapping("/sign-up")
-    public ApiResponse<Void> signIn(@RequestBody PostSignUpRequest request, HttpServletResponse httpServletResponse) {
+    public ApiResponse<Void> signIn(@Valid @RequestBody PostSignUpRequest request, HttpServletResponse httpServletResponse) {
         TokenDto response = userService.createUser(request, httpServletResponse);
         return ApiResponse.successOnly();
     }
@@ -52,7 +53,7 @@ public class UserController {
 
     @Operation(summary = "기본 정보 변경", description = "유저의 닉네임, 태어난 년도, 성별, 직업을 변경한다.")
     @PatchMapping("/info")
-    public ApiResponse<Void> updateUserBasicInfo(@RequestBody PatchBasicInfoRequest request,
+    public ApiResponse<Void> updateUserBasicInfo(@Valid @RequestBody PatchBasicInfoRequest request,
                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.modifyUserBasicInfo(request, userDetails.getId());
         return ApiResponse.successOnly();
@@ -60,7 +61,7 @@ public class UserController {
 
     @Operation(summary = "취미 및 힐링 방법 변경", description = "유저의 취미 및 힐링 방법을 변경한다.")
     @PatchMapping("/hobby-healing-style")
-    public ApiResponse<Void> updateHobbyHealingStyle(@RequestBody PatchHobbyHealingStyleRequest request,
+    public ApiResponse<Void> updateHobbyHealingStyle(@Valid @RequestBody PatchHobbyHealingStyleRequest request,
                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.modifyHobbyHealingStyle(request, userDetails.getId());
         return ApiResponse.successOnly();
@@ -68,7 +69,7 @@ public class UserController {
 
     @Operation(summary = "스트레스 해소 방법 변경", description = "유저의 기존 스트레스 해소 방법을 변경한다.")
     @PatchMapping("/stress-relief-style")
-    public ApiResponse<Void> updateStressReliefStyle(@RequestBody PatchStressReliefStyleRequest request,
+    public ApiResponse<Void> updateStressReliefStyle(@Valid @RequestBody PatchStressReliefStyleRequest request,
                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.modifyStressReliefStyle(request, userDetails.getId());
         return ApiResponse.successOnly();
@@ -76,7 +77,7 @@ public class UserController {
 
     @Operation(summary = "성향 변경", description = "유저의 기존 성향 정보를 변경한다.")
     @PatchMapping("/personality")
-    public ApiResponse<Void> updatePersonality(@RequestBody PatchPersonalityRequest request,
+    public ApiResponse<Void> updatePersonality(@Valid @RequestBody PatchPersonalityRequest request,
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.modifyPersonality(request, userDetails.getId());
         return ApiResponse.successOnly();
@@ -84,7 +85,7 @@ public class UserController {
 
     @Operation(summary = "토큰 재발급", description = "AccessToken을 재발급한다.")
     @PostMapping("/reissue-token")
-    public ApiResponse<Void> reissueToken(@RequestBody PostReissueTokenRequest request,
+    public ApiResponse<Void> reissueToken(@Valid @RequestBody PostReissueTokenRequest request,
                                           HttpServletResponse httpServletResponse) {
         userService.processReissue(request, httpServletResponse);
         return ApiResponse.successOnly();

--- a/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
@@ -71,9 +71,8 @@ public class JwtProvider {
     public TokenDto createAllToken(String email) {
         String accessToken = GRANT_TYPE + createAccessToken(email);
         String refreshToken = GRANT_TYPE + createRefreshToken(email);
-        Instant refreshTokenExpiredAt = Instant.now().plus(30, ChronoUnit.DAYS);
 
-        return new TokenDto(accessToken, refreshToken, refreshTokenExpiredAt);
+        return new TokenDto(accessToken, refreshToken);
     }
 
     public String createAccessToken(String email) {
@@ -155,6 +154,5 @@ public class JwtProvider {
     public void setResponseHeaderToken(HttpServletResponse response, TokenDto tokenDto) {
         response.setHeader("Authorization", tokenDto.getAccessToken());
         response.setHeader("Refresh-Token", tokenDto.getRefreshToken());
-        response.setHeader("Expired-At", tokenDto.getRefreshTokenExpiredAt().toString());
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
@@ -3,6 +3,7 @@ package com.konkuk.strhat.domain.user.application;
 import com.konkuk.strhat.domain.user.dao.RefreshTokenRepository;
 import com.konkuk.strhat.domain.user.dto.TokenDto;
 import com.konkuk.strhat.domain.user.entity.RefreshToken;
+import com.konkuk.strhat.domain.user.exception.MissingTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -55,6 +56,11 @@ public class JwtProvider {
 
     public String getHeaderToken(HttpServletRequest request) {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (token == null || token.isBlank()) {
+            throw new MissingTokenException();
+        }
+
         if (token.startsWith("Bearer ")) {
             return token.substring(7);
         }
@@ -102,10 +108,11 @@ public class JwtProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
+        } catch (ExpiredJwtException exception) {
+            throw exception;
         } catch (UnsupportedJwtException
                  | MalformedJwtException
                  | SignatureException
-                 | ExpiredJwtException
                  | IllegalArgumentException exception) {
             throw new JwtException("");
         }

--- a/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
@@ -4,6 +4,7 @@ import com.konkuk.strhat.domain.user.dao.RefreshTokenRepository;
 import com.konkuk.strhat.domain.user.dto.TokenDto;
 import com.konkuk.strhat.domain.user.entity.RefreshToken;
 import com.konkuk.strhat.domain.user.exception.MissingTokenException;
+import com.konkuk.strhat.domain.user.exception.NotFoundRefreshTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -127,11 +128,14 @@ public class JwtProvider {
                 .get("email", String.class);
     }
 
-    public Boolean validateRefreshToken(String refreshToken) {
+    public RefreshToken validateRefreshToken(String refreshToken) {
         validateToken(refreshToken);
         String email = getEmailByToken(refreshToken);
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findRefreshTokenByEmail(email);
-        return optionalRefreshToken.isPresent();
+        if (optionalRefreshToken.isEmpty()) {
+            throw new NotFoundRefreshTokenException();
+        }
+        return optionalRefreshToken.get();
     }
 
     public Date getExpiredAt(String token) {

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,8 +15,8 @@ public class PatchBasicInfoRequest {
     private String nickname;
 
     @NotNull
-    @Min(1000)
-    @Max(9999)
+    @Min(1901)
+    @Max(2155)
     private Integer birth;
 
     @NotBlank

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
@@ -1,5 +1,8 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,8 +10,16 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchBasicInfoRequest {
+    @NotBlank
     private String nickname;
+
+    @NotNull
+    @Digits(integer = 4, fraction = 0)
     private Integer birth;
+
+    @NotBlank
     private String gender;
+
+    @NotBlank
     private String job;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchBasicInfoRequest.java
@@ -1,8 +1,10 @@
 package com.konkuk.strhat.domain.user.dto;
 
-import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +16,8 @@ public class PatchBasicInfoRequest {
     private String nickname;
 
     @NotNull
-    @Digits(integer = 4, fraction = 0)
+    @Min(1000)
+    @Max(9999)
     private Integer birth;
 
     @NotBlank

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchHobbyHealingStyleRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchHobbyHealingStyleRequest.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchHobbyHealingStyleRequest {
+    @NotBlank
     private String hobbyHealingStyle;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchHobbyHealingStyleRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchHobbyHealingStyleRequest.java
@@ -4,10 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchHobbyHealingStyleRequest {
     @NotBlank
+    @Length(min = 20, max = 1000)
     private String hobbyHealingStyle;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchPersonalityRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchPersonalityRequest.java
@@ -4,10 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchPersonalityRequest {
     @NotBlank
+    @Length(min = 20, max = 1000)
     private String personality;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchPersonalityRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchPersonalityRequest.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchPersonalityRequest {
+    @NotBlank
     private String personality;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchStressReliefStyleRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchStressReliefStyleRequest.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchStressReliefStyleRequest {
+    @NotBlank
     private String stressReliefStyle;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PatchStressReliefStyleRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PatchStressReliefStyleRequest.java
@@ -4,10 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PatchStressReliefStyleRequest {
     @NotBlank
+    @Length(min = 20, max = 1000)
     private String stressReliefStyle;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInRequest.java
@@ -1,10 +1,12 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class PostKakaoSignInRequest {
+    @NotBlank
     private String kakaoAccessToken;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostReissueTokenRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostReissueTokenRequest.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,5 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostReissueTokenRequest {
+    @NotBlank
     private String refreshToken;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -1,17 +1,43 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor
 public class PostSignUpRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력값입니다.")
     private String nickname;
+
+    @NotNull(message = "출생년도는 필수 입력값입니다.")
+    @Digits(integer = 4, fraction = 0, message = "올바른 출생년도 형식이 아닙니다.")
     private Integer birth;
+
+    @NotBlank(message = "성별은 필수 입력값입니다.")
     private String gender;
+
+    @NotBlank(message = "직업은 필수 입력값입니다.")
     private String job;
+
+    @NotBlank(message = "취미 및 힐링 방법은 필수 입력값입니다.")
+    @Length(min = 20, max = 1000, message = "취미 및 힐링 방법은 20자 이상 1000자 이하이어야 합니다.")
     private String hobbyHealingStyle;
+
+    @NotBlank(message = "스트레스 해소 방법은 필수 입력값입니다.")
+    @Length(min = 20, max = 1000, message = "스트레스 해소 방법은 20자 이상 1000자 이하이어야 합니다.")
     private String stressReliefStyle;
+
+    @NotBlank(message = "성향은 필수 입력값입니다.")
+    @Length(min = 20, max = 1000, message = "성향은 20자 이상 1000자 이하이어야 합니다.")
     private String personality;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -13,33 +13,33 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 public class PostSignUpRequest {
 
-    @NotBlank(message = "이메일은 필수 입력값입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank
+    @Email
     private String email;
 
-    @NotBlank(message = "닉네임은 필수 입력값입니다.")
+    @NotBlank
     private String nickname;
 
-    @NotNull(message = "출생년도는 필수 입력값입니다.")
+    @NotNull
     @Min(1000)
     @Max(9999)
     private Integer birth;
 
-    @NotBlank(message = "성별은 필수 입력값입니다.")
+    @NotBlank
     private String gender;
 
-    @NotBlank(message = "직업은 필수 입력값입니다.")
+    @NotBlank
     private String job;
 
-    @NotBlank(message = "취미 및 힐링 방법은 필수 입력값입니다.")
-    @Length(min = 20, max = 1000, message = "취미 및 힐링 방법은 20자 이상 1000자 이하이어야 합니다.")
+    @NotBlank
+    @Length(min = 20, max = 1000)
     private String hobbyHealingStyle;
 
-    @NotBlank(message = "스트레스 해소 방법은 필수 입력값입니다.")
-    @Length(min = 20, max = 1000, message = "스트레스 해소 방법은 20자 이상 1000자 이하이어야 합니다.")
+    @NotBlank
+    @Length(min = 20, max = 1000)
     private String stressReliefStyle;
 
-    @NotBlank(message = "성향은 필수 입력값입니다.")
-    @Length(min = 20, max = 1000, message = "성향은 20자 이상 1000자 이하이어야 합니다.")
+    @NotBlank
+    @Length(min = 20, max = 1000)
     private String personality;
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -18,11 +18,12 @@ public class PostSignUpRequest {
     private String email;
 
     @NotBlank
+    @Length(max = 5)
     private String nickname;
 
     @NotNull
-    @Min(1000)
-    @Max(9999)
+    @Min(1901)
+    @Max(2155)
     private Integer birth;
 
     @NotBlank

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -1,7 +1,8 @@
 package com.konkuk.strhat.domain.user.dto;
 
-import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -20,7 +21,8 @@ public class PostSignUpRequest {
     private String nickname;
 
     @NotNull(message = "출생년도는 필수 입력값입니다.")
-    @Digits(integer = 4, fraction = 0, message = "올바른 출생년도 형식이 아닙니다.")
+    @Min(1000)
+    @Max(9999)
     private Integer birth;
 
     @NotBlank(message = "성별은 필수 입력값입니다.")

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/TokenDto.java
@@ -5,28 +5,23 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenDto {
 
     private String accessToken;
     private String refreshToken;
-    private Instant refreshTokenExpiredAt;
 
     @Builder
-    public TokenDto(String accessToken, String refreshToken, Instant refreshTokenExpiredAt) {
+    public TokenDto(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.refreshTokenExpiredAt = refreshTokenExpiredAt;
     }
 
     public static TokenDto empty() {
         return TokenDto.builder()
                 .accessToken(null)
                 .refreshToken(null)
-                .refreshTokenExpiredAt(null)
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/entity/RefreshToken.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,7 +15,10 @@ public class RefreshToken {
 
     @Id
     private String id;
+
     private String refreshToken;
+
+    @Indexed
     private String email;
 
     @Builder

--- a/src/main/java/com/konkuk/strhat/domain/user/exception/MissingTokenException.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/exception/MissingTokenException.java
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.user.exception;
+
+import com.konkuk.strhat.global.error.CustomException;
+import com.konkuk.strhat.global.error.ErrorCode;
+
+public class MissingTokenException extends CustomException {
+
+    public MissingTokenException() {
+        super(ErrorCode.MISSING_TOKEN);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/global/config/RedisConfig.java
+++ b/src/main/java/com/konkuk/strhat/global/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
@@ -11,15 +12,22 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
-    private int port;
+    @Value("${spring.data.redis.port}")
+    private String port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(port));
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
 }

--- a/src/main/java/com/konkuk/strhat/global/config/RedisConfig.java
+++ b/src/main/java/com/konkuk/strhat/global/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.konkuk.strhat.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/global/config/SecurityConfig.java
+++ b/src/main/java/com/konkuk/strhat/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.konkuk.strhat.global.config;
 
 import com.konkuk.strhat.domain.user.application.JwtProvider;
 import com.konkuk.strhat.global.filter.JwtAuthenticationFilter;
+import com.konkuk.strhat.global.filter.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "swagger-ui.html", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
+++ b/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
 
     // JWT
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "J404", "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "J400", "올바르지 않은 토큰값입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "J401", "토큰의 유효기간이 만료되었습니다."),
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "헤더에 토큰이 존재하지 않습니다."),
 
     // AI (GPI API)
     GPT_FEEDBACK_GENERATION_FAIL(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 이용한 피드백 생성에 실패하였습니다."),

--- a/src/main/java/com/konkuk/strhat/global/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/konkuk/strhat/global/filter/JwtExceptionFilter.java
@@ -1,0 +1,45 @@
+package com.konkuk.strhat.global.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konkuk.strhat.domain.user.exception.MissingTokenException;
+import com.konkuk.strhat.global.error.ErrorCode;
+import com.konkuk.strhat.global.response.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        try {
+            chain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            setErrorResponse(response, ErrorCode.TOKEN_EXPIRED);
+        } catch (MissingTokenException e) {
+            setErrorResponse(response, ErrorCode.MISSING_TOKEN);
+        }catch (JwtException e) {
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        ErrorResponse errorResponse = ErrorResponse.fromErrorCode(errorCode);
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        }catch (IOException e){
+            log.error(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/global/util/SecurityUtil.java
+++ b/src/main/java/com/konkuk/strhat/global/util/SecurityUtil.java
@@ -21,5 +21,18 @@ public class SecurityUtil {
 
         return customUserDetails.getId();
     }
+
+    public static String getCurrentUserEmail() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new NotFoundUserException();
+        }
+
+        if (!(authentication.getPrincipal() instanceof CustomUserDetails customUserDetails)) {
+            throw new NotFoundUserException();
+        }
+
+        return customUserDetails.getEmail();
+    }
 }
 


### PR DESCRIPTION
### ✏️ 이슈 번호
- closed #12 

### ⛳ 작업 분류
- [x] 작업1 Request 유효성 검증
- [x] 작업2 토큰 예외 처리
- [x] 작업3 Reissue API 문제 해결

### 🔨 작업 상세 내용
1. Spring Valdiation 어노테이션을 사용하여 각각의 Request마다 유효성 검증을 진행하였습니다.
2. JwtExceptionFilter를 구현하여 토큰과 관련된 예외를 처리하도록 하였습니다.
3. Redis 문제로 Email 값으로 RefreshToken을 찾지 못하던 오류를 수정하였습니다.

### 💡 생각해볼 문제
- 현재 User의 출생년도가 DB에 YEAR로 저장되는데, YEAR의 경우 1901~2155 범위 밖의 숫자가 오는 경우 문제가 발생합니다. 우선 MIN, MAX 어노테이션으로 막아두었습니다.
