### PR TITLE
[DOCS] Swagger 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,4 +34,6 @@ springdoc:
     path: /api-test
     groups-order: DESC  # path, query, body, response ? ??
     tags-sorter: alpha  # ?? ??? ? ??
-    operations-sorter: method  # delete - get - patch - post - put ? ??
+    operations-sorter: default
+    persist-authorization: true
+    display-request-duration: true


### PR DESCRIPTION
### ✏️ 이슈 번호
- close #16 

### ⛳ 작업 분류
- [x] 작업1 API 정렬 순서 변경
- [x] 작업2 Request Duration 추가
- [x] 작업3 토큰값 유지

### 🔨 작업 상세 내용
1. 기존의 operation-sorter가 method로 설정되어 있던 것을 default로 바꾸었습니다. 
2. Request Duration을 API를 호출했을 때 확인할 수 있도록 추가하였습니다.
3. Authorize에 입력한 토큰값이 새로고침과 같은 작업 이후에도 유지되도록 수정하였습니다.

### 💡 생각해볼 문제
- operation-sorter를 method에서 default로 변경한 이유는 대부분의 흐름이 POST에서 시작하는데 method 방식의 경우 DELTE - GET - PATCH - POST - PUT의 순서로 정렬되었던 점에 불편함을 느껴 수정하게 되었습니다. 현재 구현된 API 상에서는 POST가 맨 위로 정렬되는 상황이나, default 방식의 정확한 정렬 기준은 모르겠습니다.
