### PR TITLE
[FIX] unique 복합 제약 조건 적용

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/entity/Diary.java
@@ -7,7 +7,12 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "diary")
+@Table(
+        name = "diary",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "diary_date"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Diary {
@@ -24,7 +29,7 @@ public class Diary {
     @Column(name = "emotion", nullable = false)
     private Integer emotion;
 
-    @Column(name = "diary_date", nullable = false, unique = true)
+    @Column(name = "diary_date", nullable = false)
     private LocalDate diaryDate;
 
     @Setter

--- a/src/main/java/com/konkuk/strhat/domain/diary/entity/Feedback.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/entity/Feedback.java
@@ -1,14 +1,6 @@
 package com.konkuk.strhat.domain.diary.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +9,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "feedback")
+@Table(
+        name = "feedback",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"diary_id", "feedback_date"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feedback {
@@ -39,7 +36,7 @@ public class Feedback {
     @Column(name = "stress_relief_suggestion",length = 255, nullable = false)
     private String stressReliefSuggestion;
 
-    @Column(name = "feedback_date", nullable = false, unique = true)
+    @Column(name = "feedback_date", nullable = false)
     private LocalDate feedbackDate;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/konkuk/strhat/domain/diary/entity/StressScore.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/entity/StressScore.java
@@ -1,14 +1,6 @@
 package com.konkuk.strhat.domain.diary.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +9,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "stress_score")
+@Table(
+        name = "stress_score",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"diary_id", "stress_score_date"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StressScore {
@@ -33,7 +30,7 @@ public class StressScore {
     @Column(name = "stress_factor", length = 255, nullable = false)
     private String stressFactor;
 
-    @Column(name = "stress_score_date", nullable = false, unique = true)
+    @Column(name = "stress_score_date", nullable = false)
     private LocalDate stressScoreDate;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/konkuk/strhat/domain/self_diagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/domain/self_diagnosis/entity/SelfDiagnosis.java
@@ -7,7 +7,12 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "self_diagnosis")
+@Table(
+        name = "self_diagnosis",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "self_diagnosis_date"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SelfDiagnosis {
@@ -24,7 +29,7 @@ public class SelfDiagnosis {
     @Column(name = "type", length = 10, nullable = false)
     private SelfDiagnosisType type;
 
-    @Column(name = "self_diagnosis_date", nullable = false, unique = true)
+    @Column(name = "self_diagnosis_date", nullable = false)
     private LocalDate selfDiagnosisDate;
 
     @Setter


### PR DESCRIPTION
### ✏️ 이슈 번호
- #10

### ⛳ 작업 분류
- [x] date 관련 컬럼의 단일 unique 제약 조건 제거
- [x] user_id와 date 관련 컬럼에 대한 복합 유니크 제약 조건 추가

### 🔨 작업 상세 내용
- 기존에는 diary_date 컬럼에 단일 unique 제약 조건이 설정되어 있어, 모든 사용자에 대해 동일한 날짜에 하나의 일기만 작성 가능한 잘못된 구조였습니다. 이를 사용자별로 하나의 날짜만 허용되도록, user_id와 date 컬럼에 대해 복합 유니크 제약 조건으로 수정하였습니다.
