### PR TITLE
[FEAT] GPT API 연결 및 일기 관련 API 구현 완료

### DIFF
--- a/src/main/java/com/konkuk/strhat/StrhatApplication.java
+++ b/src/main/java/com/konkuk/strhat/StrhatApplication.java
@@ -1,14 +1,17 @@
 package com.konkuk.strhat;
 
+import com.konkuk.strhat.ai.web_client.GptProperties;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableConfigurationProperties(GptProperties.class)
 public class StrhatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/konkuk/strhat/ai/GptServiceTest.java
+++ b/src/main/java/com/konkuk/strhat/ai/GptServiceTest.java
@@ -1,0 +1,21 @@
+package com.konkuk.strhat.ai;
+
+import com.konkuk.strhat.ai.dto.GptReplyResult;
+import com.konkuk.strhat.ai.prompt.GptPrompt;
+import com.konkuk.strhat.ai.util.GptResponseParser;
+import com.konkuk.strhat.ai.web_client.GptClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GptServiceTest {
+
+    private final GptClient gptClient;
+    private final GptResponseParser gptResponseParser;
+
+    public <T> T requestAndParse(GptPrompt prompt, Class<T> valueType) {
+        GptReplyResult result = gptClient.chat(prompt);
+        return gptResponseParser.parse(result, valueType);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/dto/GptReplyResult.java
+++ b/src/main/java/com/konkuk/strhat/ai/dto/GptReplyResult.java
@@ -1,0 +1,12 @@
+package com.konkuk.strhat.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GptReplyResult {
+    private String status;
+    private String type;
+    private String text;
+}

--- a/src/main/java/com/konkuk/strhat/ai/dto/GptRequest.java
+++ b/src/main/java/com/konkuk/strhat/ai/dto/GptRequest.java
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.ai.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class GptRequest {
+    private String model;
+    private List<GptRequestMessage> input;
+    private Double temperature;
+}

--- a/src/main/java/com/konkuk/strhat/ai/dto/GptRequestMessage.java
+++ b/src/main/java/com/konkuk/strhat/ai/dto/GptRequestMessage.java
@@ -1,0 +1,26 @@
+package com.konkuk.strhat.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GptRequestMessage {
+
+    private String role;
+    private String content;
+
+    public static GptRequestMessage system(String content) {
+        return new GptRequestMessage("system", content);
+    }
+
+    public static GptRequestMessage user(String content) {
+        return new GptRequestMessage("user", content);
+    }
+
+    public static GptRequestMessage assistant(String content) {
+        return new GptRequestMessage("assistant", content);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/dto/GptResponse.java
+++ b/src/main/java/com/konkuk/strhat/ai/dto/GptResponse.java
@@ -1,0 +1,28 @@
+package com.konkuk.strhat.ai.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+// OpenAI의 GPT Chat Completion API 응답 형식에 맞춘 구조
+@Getter
+public class GptResponse {
+    private String id;
+    private String model;
+    private List<Output> output;
+
+    @Getter
+    public static class Output {
+        private String type;
+        private String id;
+        private String status;
+        private String role;
+        private List<Content> content;
+    }
+
+    @Getter
+    public static class Content {
+        private String type;
+        private String text;
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/exception/GptResponseParseException.java
+++ b/src/main/java/com/konkuk/strhat/ai/exception/GptResponseParseException.java
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.ai.exception;
+
+import com.konkuk.strhat.global.error.CustomException;
+import com.konkuk.strhat.global.error.ErrorCode;
+
+public class GptResponseParseException extends CustomException {
+
+    public GptResponseParseException(String message) {
+        super(ErrorCode.GPT_RESPONSE_PARSE_FAIL, message);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/GptPrompt.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/GptPrompt.java
@@ -1,0 +1,9 @@
+package com.konkuk.strhat.ai.prompt;
+
+import com.konkuk.strhat.ai.dto.GptRequestMessage;
+
+import java.util.List;
+
+public interface GptPrompt {
+    List<GptRequestMessage> toMessages();
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackPrompt.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackPrompt.java
@@ -1,0 +1,59 @@
+package com.konkuk.strhat.ai.prompt.diary_feedback;
+
+import com.konkuk.strhat.ai.dto.GptRequestMessage;
+import com.konkuk.strhat.ai.prompt.GptPrompt;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt.DiaryFeedbackFieldNames.POSITIVE;
+import static com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt.DiaryFeedbackFieldNames.NEGATIVE;
+import static com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt.DiaryFeedbackFieldNames.SUMMARY;
+import static com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt.DiaryFeedbackFieldNames.SUGGESTION;
+
+@RequiredArgsConstructor
+public class DiaryFeedbackPrompt implements GptPrompt {
+
+    private final DiaryFeedbackRequestDto request;
+
+    @Override
+    public List<GptRequestMessage> toMessages() {
+        return List.of(
+                GptRequestMessage.system("당신은 심리학적 지식을 가지고 일기 피드백을 제공하는 심리 전문가입니다."),
+                GptRequestMessage.user(String.format("""
+                    [요청]
+                    1. 사용자의 정보: %s
+                    2. 사용자의 일기 내용: %s
+                    """, request.getUserTraits(), request.getDiaryContent())),
+                GptRequestMessage.assistant(String.format("""
+                    [응답 프롬프트]
+                    1. 문장은 한국어 및 친근한 존댓말 적는다.
+                    2. 응답은 "%s", "%s", "%s", "%s" 으로 나누어 보낸다.
+                    3. %s: 일기에서 느껴지는 주요 긍정 감정 명사를 3개 선정한다.
+                    4. %s: 일기에서 느껴지는 주요 부정 감정 명사를 3개 선정한다.
+                    5. %s: 사용자에게 공감하는 형식으로 일기를 요약 및 공감한다. 이모지를 1개~2개 포함한다.
+                    6. %s: 사용자의 정보를 반영하여 맞춤형 스트레스 해소 방법을 제안한다.
+
+                    [예시 응답, 형식 참고용]
+                    {
+                        "%s": ["성취감", "안도감", "즐거움"],
+                        "%s": ["불안", "긴장", "피로감"],
+                        "%s": "오늘은 알바 때문에 마음이 복잡하고 힘드셨던 하루였던 것 같아요😢 ...",
+                        "%s": "따뜻한 이불 속에서 잔잔한 음악을 들으며 ... 하는 게 어떨까요?"
+                    }
+                    """,
+                        POSITIVE, NEGATIVE, SUMMARY, SUGGESTION,
+                        POSITIVE, NEGATIVE, SUMMARY, SUGGESTION,
+                        POSITIVE, NEGATIVE, SUMMARY, SUGGESTION
+                ))
+        );
+    }
+
+    public static class DiaryFeedbackFieldNames {
+        public static final String POSITIVE = "positive_emotion_keywords";
+        public static final String NEGATIVE = "negative_emotion_keywords";
+        public static final String SUMMARY = "diary_summary";
+        public static final String SUGGESTION = "stress_relief_suggestions";
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
@@ -1,0 +1,33 @@
+package com.konkuk.strhat.ai.prompt.diary_feedback;
+
+import com.konkuk.strhat.domain.user.dto.UserInfo;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DiaryFeedbackRequestDto {
+
+    @NotBlank(message = "userTraits는 필수입니다.")
+    private final String userTraits;
+
+    @NotBlank(message = "diaryContent는 필수입니다.")
+    private final String diaryContent;
+
+    public DiaryFeedbackRequestDto(UserInfo userInfo, String diaryContent) {
+        this.userTraits = buildUserTraits(userInfo);
+        this.diaryContent = diaryContent;
+    }
+
+    private String buildUserTraits(UserInfo user) {
+        return String.format(
+                "[닉네임]: %s, [출생년도]: %d, [성별]: %s, [직업]: %s, [취미 및 힐링 방법]: %s, [스트레스 해소 스타일]: %s, [성격]: %s",
+                user.getNickname(),
+                user.getBirth(),
+                user.getGender(),
+                user.getJob(),
+                user.getHobbyHealingStyle(),
+                user.getStressReliefStyle(),
+                user.getPersonality()
+        );
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackResponseDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackResponseDto.java
@@ -1,0 +1,24 @@
+package com.konkuk.strhat.ai.prompt.diary_feedback;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+import static com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt.DiaryFeedbackFieldNames.*;
+
+@Getter
+public class DiaryFeedbackResponseDto {
+
+    @JsonProperty(POSITIVE)
+    private List<String> positiveEmotionKeywords;
+
+    @JsonProperty(NEGATIVE)
+    private List<String> negativeEmotionKeywords;
+
+    @JsonProperty(SUMMARY)
+    private String diarySummary;
+
+    @JsonProperty(SUGGESTION)
+    private String stressReliefSuggestions;
+}

--- a/src/main/java/com/konkuk/strhat/ai/util/GptResponseParser.java
+++ b/src/main/java/com/konkuk/strhat/ai/util/GptResponseParser.java
@@ -1,0 +1,45 @@
+package com.konkuk.strhat.ai.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konkuk.strhat.ai.exception.GptResponseParseException;
+import com.konkuk.strhat.ai.dto.GptReplyResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GptResponseParser {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * GPT 응답 text를 특정 DTO로 파싱
+     * @param result GptReplyResult (status, type, text 포함)
+     * @param valueType 변환할 클래스 타입
+     * @return 파싱된 객체 or null
+     */
+    public <T> T parse(GptReplyResult result, Class<T> valueType) {
+        try {
+            String cleanText = sanitize(result.getText());
+            return objectMapper.readValue(cleanText, valueType);
+        } catch (Exception e) {
+            log.error("[GPT 응답 파싱 실패] text: {}", result.getText(), e);
+            throw new GptResponseParseException(e.getMessage());
+        }
+    }
+
+    // GPT가 반환하는 ```json ... ``` 같은 마크다운 제거
+    private String sanitize(String text) {
+        if (text.startsWith("```")) {
+            int start = text.indexOf("{");
+            int end = text.lastIndexOf("}");
+            if (start >= 0 && end >= 0 && end >= start) {
+                return text.substring(start, end + 1);
+            }
+        }
+        return text;
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/ai/web_client/GptClient.java
+++ b/src/main/java/com/konkuk/strhat/ai/web_client/GptClient.java
@@ -1,0 +1,55 @@
+package com.konkuk.strhat.ai.web_client;
+
+import com.konkuk.strhat.ai.dto.GptReplyResult;
+import com.konkuk.strhat.ai.dto.GptRequest;
+import com.konkuk.strhat.ai.dto.GptResponse;
+import com.konkuk.strhat.ai.prompt.GptPrompt;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class GptClient {
+
+    private final WebClient webClient;
+    private final GptProperties gptProperties;
+
+    public GptClient(@Qualifier("openAiWebClient") WebClient webClient, GptProperties gptProperties) {
+        this.webClient = webClient;
+        this.gptProperties = gptProperties;
+    }
+
+    public GptReplyResult chat(GptPrompt prompt) {
+        GptRequest request = new GptRequest(
+                gptProperties.getModel(),
+                prompt.toMessages(),
+                gptProperties.getTemperature()
+        );
+
+        GptResponse response = webClient.post()
+                .uri("/responses")
+                .headers(headers -> {
+                    headers.setBearerAuth(gptProperties.getKey());
+                    headers.add("OpenAI-Organization", gptProperties.getOrganization());
+                    headers.add("OpenAI-Project", gptProperties.getProject());
+                })
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(GptResponse.class)
+                .block();
+
+        if (response != null && !response.getOutput().isEmpty()) {
+            GptResponse.Output out = response.getOutput().get(0);
+            String status = out.getStatus();
+            String type = out.getType();
+            String text = out.getContent() != null && !out.getContent().isEmpty()
+                    ? out.getContent().get(0).getText()
+                    : "";
+            return new GptReplyResult(status, type, text);
+        }
+
+        return new GptReplyResult("error", "none", "응답이 비어 있습니다.");
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/web_client/GptProperties.java
+++ b/src/main/java/com/konkuk/strhat/ai/web_client/GptProperties.java
@@ -1,0 +1,19 @@
+package com.konkuk.strhat.ai.web_client;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "openai.api")
+public class GptProperties {
+    private String key;
+    private String model;
+    private Double temperature;
+    private Integer maxTokens;
+    private String organization;
+    private String project;
+}

--- a/src/main/java/com/konkuk/strhat/ai/web_client/WebClientConfig.java
+++ b/src/main/java/com/konkuk/strhat/ai/web_client/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.konkuk.strhat.ai.web_client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient openAiWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.openai.com/v1")
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/api/DiaryController.java
@@ -2,6 +2,7 @@ package com.konkuk.strhat.domain.diary.api;
 
 import com.konkuk.strhat.domain.diary.application.DiaryService;
 import com.konkuk.strhat.domain.diary.dto.CheckDiaryResponse;
+import com.konkuk.strhat.domain.diary.dto.DiaryContentResponse;
 import com.konkuk.strhat.domain.diary.dto.DiarySaveRequest;
 import com.konkuk.strhat.domain.diary.dto.DiarySaveResponse;
 import com.konkuk.strhat.domain.diary.entity.Diary;
@@ -37,6 +38,14 @@ public class DiaryController {
         Long userId = SecurityUtil.getCurrentUserId();
         Diary diary = diaryService.saveDiary(userId, request);
         DiarySaveResponse response = diaryService.getFeedback(diary);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "일기 조회", description = "사용자가 작성한 일기를 조회한다. (일기 전문보기)")
+    @GetMapping
+    public ApiResponse<DiaryContentResponse> readDiary(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        DiaryContentResponse response = diaryService.readDiary(userId, date);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/konkuk/strhat/domain/diary/api/DiaryController.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/api/DiaryController.java
@@ -1,10 +1,7 @@
 package com.konkuk.strhat.domain.diary.api;
 
 import com.konkuk.strhat.domain.diary.application.DiaryService;
-import com.konkuk.strhat.domain.diary.dto.CheckDiaryResponse;
-import com.konkuk.strhat.domain.diary.dto.DiaryContentResponse;
-import com.konkuk.strhat.domain.diary.dto.DiarySaveRequest;
-import com.konkuk.strhat.domain.diary.dto.DiarySaveResponse;
+import com.konkuk.strhat.domain.diary.dto.*;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.global.response.ApiResponse;
 import com.konkuk.strhat.global.util.SecurityUtil;
@@ -46,6 +43,14 @@ public class DiaryController {
     public ApiResponse<DiaryContentResponse> readDiary(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long userId = SecurityUtil.getCurrentUserId();
         DiaryContentResponse response = diaryService.readDiary(userId, date);
+        return ApiResponse.success(response);
+    }
+
+    @Operation(summary = "피드백 조회", description = "사용자가 작성한 일기에 대한 피드백을 조회한다.")
+    @GetMapping("/feedback")
+    public ApiResponse<FeedbackResponse> readFeedback(@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        FeedbackResponse response = diaryService.readFeedback(userId, date);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -1,10 +1,8 @@
 package com.konkuk.strhat.domain.diary.application;
 
 import com.konkuk.strhat.domain.diary.dao.DiaryRepository;
-import com.konkuk.strhat.domain.diary.dto.CheckDiaryResponse;
-import com.konkuk.strhat.domain.diary.dto.DiaryContentResponse;
-import com.konkuk.strhat.domain.diary.dto.DiarySaveRequest;
-import com.konkuk.strhat.domain.diary.dto.DiarySaveResponse;
+import com.konkuk.strhat.domain.diary.dao.FeedbackRepository;
+import com.konkuk.strhat.domain.diary.dto.*;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.domain.diary.entity.Feedback;
 import com.konkuk.strhat.domain.diary.exception.DiarySaveException;
@@ -12,6 +10,7 @@ import com.konkuk.strhat.domain.diary.exception.DuplicateDiaryException;
 import com.konkuk.strhat.domain.user.dao.UserRepository;
 import com.konkuk.strhat.domain.user.entity.User;
 import com.konkuk.strhat.domain.user.exception.NotFoundUserException;
+import com.konkuk.strhat.domain.diary.exception.NotFoundFeedbackException;
 import com.konkuk.strhat.domain.diary.exception.DiaryReadException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +26,7 @@ import java.util.Optional;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
+    private final FeedbackRepository feedbackRepository;
     private final FeedbackService feedbackService;
     private final UserRepository userRepository;
 
@@ -94,5 +94,19 @@ public class DiaryService {
                 .orElseThrow(DiaryReadException::new);
 
         return DiaryContentResponse.toDiaryContentResponse(diary);
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackResponse readFeedback(Long currentUserId, LocalDate date) {
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(NotFoundUserException::new);
+
+        Diary diary = diaryRepository.findByDiaryDateAndUser(date, user)
+                .orElseThrow(DiaryReadException::new);
+
+        Feedback feedback = feedbackRepository.findByDiary(diary)
+                .orElseThrow(NotFoundFeedbackException::new);
+
+        return FeedbackResponse.toFeedbackResponse(feedback);
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -2,6 +2,7 @@ package com.konkuk.strhat.domain.diary.application;
 
 import com.konkuk.strhat.domain.diary.dao.DiaryRepository;
 import com.konkuk.strhat.domain.diary.dto.CheckDiaryResponse;
+import com.konkuk.strhat.domain.diary.dto.DiaryContentResponse;
 import com.konkuk.strhat.domain.diary.dto.DiarySaveRequest;
 import com.konkuk.strhat.domain.diary.dto.DiarySaveResponse;
 import com.konkuk.strhat.domain.diary.entity.Diary;
@@ -11,6 +12,7 @@ import com.konkuk.strhat.domain.diary.exception.DuplicateDiaryException;
 import com.konkuk.strhat.domain.user.dao.UserRepository;
 import com.konkuk.strhat.domain.user.entity.User;
 import com.konkuk.strhat.domain.user.exception.NotFoundUserException;
+import com.konkuk.strhat.domain.diary.exception.DiaryReadException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -81,5 +83,16 @@ public class DiaryService {
                 .negativeKeywords(feedback.getNegativeEmotionArray())
                 .stressReliefSuggestions(feedback.getStressReliefSuggestion())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public DiaryContentResponse readDiary(Long currentUserId, LocalDate date) {
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(NotFoundUserException::new);
+
+        Diary diary = diaryRepository.findByDiaryDateAndUser(date, user)
+                .orElseThrow(DiaryReadException::new);
+
+        return DiaryContentResponse.toDiaryContentResponse(diary);
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
@@ -1,38 +1,67 @@
 package com.konkuk.strhat.domain.diary.application;
 
+import com.konkuk.strhat.ai.dto.GptReplyResult;
+import com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackPrompt;
+import com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackRequestDto;
+import com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackResponseDto;
+import com.konkuk.strhat.ai.util.GptResponseParser;
+import com.konkuk.strhat.ai.web_client.GptClient;
+import com.konkuk.strhat.domain.diary.dao.DiaryRepository;
 import com.konkuk.strhat.domain.diary.dao.FeedbackRepository;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.domain.diary.entity.Feedback;
 import com.konkuk.strhat.domain.diary.exception.FeedbackGenerateException;
 import com.konkuk.strhat.domain.diary.exception.FeedbackSaveException;
 import com.konkuk.strhat.domain.diary.exception.InvalidFeedbackEmotionFormatException;
+import com.konkuk.strhat.domain.user.dao.UserRepository;
+import com.konkuk.strhat.domain.user.dto.UserInfo;
+import com.konkuk.strhat.domain.user.entity.User;
+import com.konkuk.strhat.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
+    private final GptClient gptClient;
+    private final GptResponseParser gptResponseParser;
+
 
     @Transactional
     public Feedback generateFeedbackAndSave(Diary diary) {
-
         Feedback feedback;
 
-        // AI 피드백 생성
         try {
-            // 임시
+            // 1. 사용자 조회
+            User user = diary.getUser();
+
+            // 2. GPT API 요청에 필요한 DTO 구성
+            UserInfo userInfo = UserInfo.from(user);
+            DiaryFeedbackRequestDto request = new DiaryFeedbackRequestDto(userInfo, diary.getContent());
+
+            // 3. Prompt 생성 및 요청
+            DiaryFeedbackPrompt prompt = new DiaryFeedbackPrompt(request);
+            GptReplyResult result = gptClient.chat(prompt);
+            DiaryFeedbackResponseDto diaryFeedbackResponseDto = gptResponseParser.parse(result, DiaryFeedbackResponseDto.class);
+
+            // 4. 피드백 객체 생성
+            String positiveEmotionKeywords = diaryFeedbackResponseDto.getPositiveEmotionKeywords().toString();
+            String negativeEmotionKeywords = diaryFeedbackResponseDto.getNegativeEmotionKeywords().toString();
             feedback = Feedback.builder()
-                    .diarySummary("오늘 하루를 잘 정리했어요.")
-                    .positiveEmotions("기쁨, 감사, 행복")
-                    .negativeEmotions("피로, 짜증, 슬픔")
-                    .stressReliefSuggestion("산책을 추천해요.")
+                    .diarySummary(diaryFeedbackResponseDto.getDiarySummary())
+                    .positiveEmotions(positiveEmotionKeywords.substring(1, positiveEmotionKeywords.length() - 1))
+                    .negativeEmotions(negativeEmotionKeywords.substring(1, negativeEmotionKeywords.length() - 1))
+                    .stressReliefSuggestion(diaryFeedbackResponseDto.getStressReliefSuggestions())
                     .diary(diary)
                     .build();
-        }catch (Exception e) {
+        } catch (Exception e) {
             throw new FeedbackGenerateException(e.getMessage());
         }
 

--- a/src/main/java/com/konkuk/strhat/domain/diary/dao/FeedbackRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dao/FeedbackRepository.java
@@ -9,4 +9,5 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+    Optional<Feedback> findByDiary(Diary diary);
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
@@ -1,0 +1,17 @@
+package com.konkuk.strhat.domain.diary.dto;
+
+import com.konkuk.strhat.domain.diary.entity.Diary;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DiaryContentResponse {
+    String content;
+
+    public static DiaryContentResponse toDiaryContentResponse(Diary diary) {
+        return DiaryContentResponse.builder()
+                .content(diary.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
@@ -20,7 +20,7 @@ public class DiarySaveRequest {
     private int emotion;
 
     @NotBlank
-    @Size(max = 1500)
+    @Size(min = 20, max = 1500)
     private String content;
 
     public Diary toDiaryEntity(User user) {

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
@@ -29,7 +29,7 @@ public class DiarySaveRequest {
                 .emotion(this.emotion)
                 .diaryDate(this.date)
                 .build();
-        diary.setUser(user);
+        user.addDiary(diary);
         return diary;
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
@@ -1,0 +1,23 @@
+package com.konkuk.strhat.domain.diary.dto;
+
+import com.konkuk.strhat.domain.diary.entity.Feedback;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedbackResponse {
+    String summary;
+    String[] positiveKeywords;
+    String[] negativeKeywords;
+    String stressReliefSuggestions;
+
+    public static FeedbackResponse toFeedbackResponse(Feedback feedback){
+        return FeedbackResponse.builder()
+                .summary(feedback.getDiarySummary())
+                .positiveKeywords(feedback.getPositiveEmotionArray())
+                .negativeKeywords(feedback.getNegativeEmotionArray())
+                .stressReliefSuggestions(feedback.getStressReliefSuggestion())
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
@@ -12,7 +12,7 @@ public class FeedbackResponse {
     String[] negativeKeywords;
     String stressReliefSuggestions;
 
-    public static FeedbackResponse toFeedbackResponse(Feedback feedback){
+    public static FeedbackResponse of(Feedback feedback){
         return FeedbackResponse.builder()
                 .summary(feedback.getDiarySummary())
                 .positiveKeywords(feedback.getPositiveEmotionArray())

--- a/src/main/java/com/konkuk/strhat/domain/diary/entity/Diary.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/entity/Diary.java
@@ -17,7 +17,6 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Diary {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_id", updatable = false)

--- a/src/main/java/com/konkuk/strhat/domain/diary/exception/NotFoundFeedbackException.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/exception/NotFoundFeedbackException.java
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.diary.exception;
+
+import com.konkuk.strhat.global.error.CustomException;
+import com.konkuk.strhat.global.error.ErrorCode;
+
+public class NotFoundFeedbackException extends CustomException {
+
+    public NotFoundFeedbackException() {
+        super(ErrorCode.NOT_FOUND_RESOURCE, "피드백 데이터가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/diary/exception/UnknownFeedbackGenerateException.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/exception/UnknownFeedbackGenerateException.java
@@ -1,0 +1,10 @@
+package com.konkuk.strhat.domain.diary.exception;
+
+import com.konkuk.strhat.global.error.CustomException;
+import com.konkuk.strhat.global.error.ErrorCode;
+
+public class UnknownFeedbackGenerateException extends CustomException {
+    public UnknownFeedbackGenerateException(String message) {
+        super(ErrorCode.UNKNOWN_GPT_ERROR, message);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/UserInfo.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/UserInfo.java
@@ -1,0 +1,32 @@
+package com.konkuk.strhat.domain.user.dto;
+
+import com.konkuk.strhat.domain.user.entity.User;
+import com.konkuk.strhat.domain.user.enums.Gender;
+import com.konkuk.strhat.domain.user.enums.Job;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfo {
+
+    private final String nickname;
+    private final Integer birth;
+    private final Gender gender;
+    private final Job job;
+    private final String hobbyHealingStyle;
+    private final String stressReliefStyle;
+    private final String personality;
+
+    public static UserInfo from(User user) {
+        return UserInfo.builder()
+                .nickname(user.getNickname())
+                .birth(user.getBirth())
+                .gender(user.getGender())
+                .job(user.getJob())
+                .hobbyHealingStyle(user.getHobbyHealingStyle())
+                .stressReliefStyle(user.getStressReliefStyle())
+                .personality(user.getPersonality())
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
+++ b/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
@@ -17,10 +17,13 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "U404", "유저가 존재하지 않습니다"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "U405", "허용되지 않는 메서드입니다"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U409", "이미 존재하는 이메일입니다."),
-    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "U409", "중복해서 저장할 수 없습니다."),
     UNSUPPORTED_GENDER_TYPE(HttpStatus.BAD_REQUEST, "U400", "지원하지 않는 성별 타입입니다."),
     UNSUPPORTED_JOB_TYPE(HttpStatus.BAD_REQUEST, "U400", "지원하지 않는 직업 타입입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "U400", "올바르지 않은 값 또는 형식입니다."),
+
+    // Resource
+    NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, "R404", "요청한 리소스가 존재하지 않습니다."),
+    DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "R409", "중복해서 저장할 수 없습니다."),
 
     // JWT
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "J404", "토큰이 존재하지 않습니다."),

--- a/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
+++ b/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
@@ -32,8 +32,10 @@ public enum ErrorCode {
     MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "J401", "헤더에 토큰이 존재하지 않습니다."),
 
     // AI (GPI API)
+    UNKNOWN_GPT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A500", "GPT API를 이용하는 로직에서 알 수 없는 이유로 실패하였습니다."),
     GPT_FEEDBACK_GENERATION_FAIL(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 이용한 피드백 생성에 실패하였습니다."),
-    INVALID_FEEDBACK_EMOTION_FORMAT(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 피드백 결과 중 감정 키워드 형식이 잘못되었습니다.");
+    INVALID_FEEDBACK_EMOTION_FORMAT(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 피드백 결과 중 감정 키워드 형식이 잘못되었습니다."),
+    GPT_RESPONSE_PARSE_FAIL(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 얻은 결과를 객체로 변환하는 도중 오류가 발생했습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,13 @@ springdoc:
     operations-sorter: default
     persist-authorization: true
     display-request-duration: true
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY}
+    model: gpt-4o
+#    model: gpt-3.5-turbo
+    organization: ${OPENAI_ORGANIZATION}
+    project: ${OPENAI_PROJECT_ID}
+    temperature: 0.7
+    max-tokens: 500


### PR DESCRIPTION
### ✏️ 이슈 번호
- #21

### ⛳ 작업 분류
- [x] GPT API 연결
- [x] 일기 도메인 관련 API 구현 모두 완료

### 🔨 작업 상세 내용
1. 피드백 조회 API 구현을 완료하였습니다.
2. 일기 조회 (일기 전문 보기) API 구현을 완료하였습니다.
3. 일기 저장 및 피드백 조회 API에서 피드백 생성 로직을 구현하였습니다.
   - 피드백 생성 오류가 발생한 경우, 최대 3번까지 생성 요청을 다시 보냅니다. 그럼에도 실패한 경우, 프론트로 오류 응답을 보냅니다.
4. GPT API 요청 관련 로직은 추후 타 AI 서비스를 이용할 것을 고려하고 있습니다.
   - 클래스 및 디렉토리명에 `GPT`라는 문구를 포함시켰습니다.
   - 추후 사용하려는 AI 모델이 바뀌더라도, 바뀌는 부분은 `generateFeedbackAndSave()`메소드 하나 입니다. 
6. `GptPrompt`를 인터페이스로 정의한 이유는, 이를 구현하여 일기 피드백 전용 프롬프트 클래스(`DiaryFeedbackPrompt`), 챗봇 대화 전용 프롬프트 클래스 등 다양한 목적에 맞는 프롬프트 클래스를 확장 가능하게 만들기 위함입니다.
7. `GptServiceTest`클래스는 테스트의 편의성을 위해 임시로 만들어둔 클래스입니다.

### 💡 생각해볼 문제
- 이 PR 이후, 환경변수 추가가 필요합니다. 정보는 노션에 기록해두었습니다.
