### PR TITLE
[FIX] 감정 키워드가 잘못되었을 때도 재요청 3번 가도록 수정

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -86,7 +86,7 @@ public class DiaryService {
         for (int attempt = 1; attempt <= maxRetries + 1; attempt++) {
             try {
                 return feedbackService.generateFeedbackAndSave(diary);
-            } catch (FeedbackGenerateException e) {
+            } catch (Exception e) {
                 boolean isLastAttempt = (attempt == maxRetries + 1);
                 log.warn("피드백 생성 실패 (시도 {}/{}): {}", attempt, maxRetries + 1, e.getMessage());
 


### PR DESCRIPTION
### ✏️ 이슈 번호
X

### ⛳ 작업 분류
- [x] 에러 핸들링 수정

### 🔨 작업 상세 내용
1. GPT가 생성한 일기 피드백 중 감정 키워드가 잘못되었을 때에는 재요청 3번이 가지 않는 문제가 있었습니다. 재시도를 할 수 있도록, FeedbackGenerateException 대신 Exception 을 catch하도록 변경하였습니다.