### PR TITLE
[REFACTOR] DTO 관련 코드 컨벤션 적용

### DIFF
--- a/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
@@ -1,6 +1,6 @@
 package com.konkuk.strhat.ai.prompt.diary_feedback;
 
-import com.konkuk.strhat.domain.user.dto.UserInfo;
+import com.konkuk.strhat.domain.user.dto.UserInfoDto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +15,14 @@ public class DiaryFeedbackRequestDto {
     @NotBlank(message = "diaryContent는 필수입니다.")
     private final String diaryContent;
 
-    public static DiaryFeedbackRequestDto of(UserInfo userInfo, String diaryContent) {
+    public static DiaryFeedbackRequestDto of(UserInfoDto userInfoDto, String diaryContent) {
         return DiaryFeedbackRequestDto.builder()
-                .userTraits(buildUserTraits(userInfo))
+                .userTraits(buildUserTraits(userInfoDto))
                 .diaryContent(diaryContent)
                 .build();
     }
 
-    private static String buildUserTraits(UserInfo user) {
+    private static String buildUserTraits(UserInfoDto user) {
         return String.format(
                 "[닉네임]: %s, [출생년도]: %d, [성별]: %s, [직업]: %s, [취미 및 힐링 방법]: %s, [스트레스 해소 스타일]: %s, [성격]: %s",
                 user.getNickname(),

--- a/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/diary_feedback/DiaryFeedbackRequestDto.java
@@ -2,9 +2,11 @@ package com.konkuk.strhat.ai.prompt.diary_feedback;
 
 import com.konkuk.strhat.domain.user.dto.UserInfo;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class DiaryFeedbackRequestDto {
 
     @NotBlank(message = "userTraits는 필수입니다.")
@@ -13,12 +15,14 @@ public class DiaryFeedbackRequestDto {
     @NotBlank(message = "diaryContent는 필수입니다.")
     private final String diaryContent;
 
-    public DiaryFeedbackRequestDto(UserInfo userInfo, String diaryContent) {
-        this.userTraits = buildUserTraits(userInfo);
-        this.diaryContent = diaryContent;
+    public static DiaryFeedbackRequestDto of(UserInfo userInfo, String diaryContent) {
+        return DiaryFeedbackRequestDto.builder()
+                .userTraits(buildUserTraits(userInfo))
+                .diaryContent(diaryContent)
+                .build();
     }
 
-    private String buildUserTraits(UserInfo user) {
+    private static String buildUserTraits(UserInfo user) {
         return String.format(
                 "[닉네임]: %s, [출생년도]: %d, [성별]: %s, [직업]: %s, [취미 및 힐링 방법]: %s, [스트레스 해소 스타일]: %s, [성격]: %s",
                 user.getNickname(),

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -38,17 +38,9 @@ public class DiaryService {
         if(diary.isPresent()){
             Integer emotion = diary.get().getEmotion();
             String content = diary.get().getContent();
-            response = CheckDiaryResponse.builder()
-                    .hasDiary(true)
-                    .emotion(emotion)
-                    .summary(content.substring(0, Math.min(content.length(), 70)))
-                    .build();
+            response = CheckDiaryResponse.of(true, emotion, content.substring(0, Math.min(content.length(), 70)));
         } else{
-            response = CheckDiaryResponse.builder()
-                    .hasDiary(false)
-                    .emotion(null)
-                    .summary(null)
-                    .build();
+            response = CheckDiaryResponse.of(false, null, null);
         }
         return response;
     }
@@ -74,12 +66,11 @@ public class DiaryService {
     @Transactional
     public DiarySaveResponse getFeedback(Diary diary) {
         Feedback feedback = tryGenerateFeedbackWithRetry(diary, 2);
-        return DiarySaveResponse.builder()
-                .summary(feedback.getDiarySummary())
-                .positiveKeywords(feedback.getPositiveEmotionArray())
-                .negativeKeywords(feedback.getNegativeEmotionArray())
-                .stressReliefSuggestions(feedback.getStressReliefSuggestion())
-                .build();
+        return DiarySaveResponse.of(
+                feedback.getDiarySummary(),
+                feedback.getPositiveEmotionArray(),
+                feedback.getNegativeEmotionArray(),
+                feedback.getStressReliefSuggestion());
     }
 
     private Feedback tryGenerateFeedbackWithRetry(Diary diary, int maxRetries) {
@@ -122,6 +113,6 @@ public class DiaryService {
         Feedback feedback = feedbackRepository.findByDiary(diary)
                 .orElseThrow(NotFoundFeedbackException::new);
 
-        return FeedbackResponse.of(feedback);
+        return FeedbackResponse.from(feedback);
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -108,7 +108,7 @@ public class DiaryService {
         Diary diary = diaryRepository.findByDiaryDateAndUser(date, user)
                 .orElseThrow(DiaryReadException::new);
 
-        return DiaryContentResponse.toDiaryContentResponse(diary);
+        return DiaryContentResponse.from(diary);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
@@ -44,7 +44,7 @@ public class FeedbackService {
 
             // 2. GPT API 요청에 필요한 DTO 구성
             UserInfo userInfo = UserInfo.from(user);
-            DiaryFeedbackRequestDto request = new DiaryFeedbackRequestDto(userInfo, diary.getContent());
+            DiaryFeedbackRequestDto request = DiaryFeedbackRequestDto.of(userInfo, diary.getContent());
 
             // 3. Prompt 생성 및 요청
             DiaryFeedbackPrompt prompt = new DiaryFeedbackPrompt(request);

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/FeedbackService.java
@@ -6,24 +6,18 @@ import com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackRequestDto;
 import com.konkuk.strhat.ai.prompt.diary_feedback.DiaryFeedbackResponseDto;
 import com.konkuk.strhat.ai.util.GptResponseParser;
 import com.konkuk.strhat.ai.web_client.GptClient;
-import com.konkuk.strhat.domain.diary.dao.DiaryRepository;
 import com.konkuk.strhat.domain.diary.dao.FeedbackRepository;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.domain.diary.entity.Feedback;
 import com.konkuk.strhat.domain.diary.exception.FeedbackGenerateException;
 import com.konkuk.strhat.domain.diary.exception.FeedbackSaveException;
 import com.konkuk.strhat.domain.diary.exception.InvalidFeedbackEmotionFormatException;
-import com.konkuk.strhat.domain.user.dao.UserRepository;
-import com.konkuk.strhat.domain.user.dto.UserInfo;
+import com.konkuk.strhat.domain.user.dto.UserInfoDto;
 import com.konkuk.strhat.domain.user.entity.User;
-import com.konkuk.strhat.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -43,8 +37,8 @@ public class FeedbackService {
             User user = diary.getUser();
 
             // 2. GPT API 요청에 필요한 DTO 구성
-            UserInfo userInfo = UserInfo.from(user);
-            DiaryFeedbackRequestDto request = DiaryFeedbackRequestDto.of(userInfo, diary.getContent());
+            UserInfoDto userInfoDto = UserInfoDto.from(user);
+            DiaryFeedbackRequestDto request = DiaryFeedbackRequestDto.of(userInfoDto, diary.getContent());
 
             // 3. Prompt 생성 및 요청
             DiaryFeedbackPrompt prompt = new DiaryFeedbackPrompt(request);

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/CheckDiaryResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/CheckDiaryResponse.java
@@ -1,12 +1,24 @@
 package com.konkuk.strhat.domain.diary.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
-@Builder
+@Builder(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class CheckDiaryResponse {
     private final boolean hasDiary;
     private final Integer emotion;
     private final String summary;
+
+    public static CheckDiaryResponse of(boolean hasDiary, Integer emotion, String summary){
+        return CheckDiaryResponse.builder()
+                .hasDiary(hasDiary)
+                .emotion(emotion)
+                .summary(summary)
+                .build();
+    }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
@@ -1,13 +1,18 @@
 package com.konkuk.strhat.domain.diary.dto;
 
 import com.konkuk.strhat.domain.diary.entity.Diary;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class DiaryContentResponse {
-    String content;
+    private final String content;
 
     public static DiaryContentResponse from(Diary diary) {
         return DiaryContentResponse.builder()

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public class DiaryContentResponse {
     String content;
 
-    public static DiaryContentResponse toDiaryContentResponse(Diary diary) {
+    public static DiaryContentResponse from(Diary diary) {
         return DiaryContentResponse.builder()
                 .content(diary.getContent())
                 .build();

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveRequest.java
@@ -3,13 +3,14 @@ package com.konkuk.strhat.domain.diary.dto;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.domain.user.entity.User;
 import jakarta.validation.constraints.*;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiarySaveRequest {
 
     @NotNull

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveResponse.java
@@ -1,13 +1,27 @@
 package com.konkuk.strhat.domain.diary.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class DiarySaveResponse {
-    private String summary;
-    private String[] positiveKeywords;
-    private String[] negativeKeywords;
-    private String stressReliefSuggestions;
+    private final String summary;
+    private final String[] positiveKeywords;
+    private final String[] negativeKeywords;
+    private final String stressReliefSuggestions;
+
+    public static DiarySaveResponse of(String summary, String[] positiveKeywords, String[] negativeKeywords, String stressReliefSuggestions){
+        return DiarySaveResponse.builder()
+                .summary(summary)
+                .positiveKeywords(positiveKeywords)
+                .negativeKeywords(negativeKeywords)
+                .stressReliefSuggestions(stressReliefSuggestions)
+                .build();
+    }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
@@ -1,18 +1,23 @@
 package com.konkuk.strhat.domain.diary.dto;
 
 import com.konkuk.strhat.domain.diary.entity.Feedback;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@Builder
-public class FeedbackResponse {
-    String summary;
-    String[] positiveKeywords;
-    String[] negativeKeywords;
-    String stressReliefSuggestions;
+import static lombok.AccessLevel.PRIVATE;
 
-    public static FeedbackResponse of(Feedback feedback){
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class FeedbackResponse {
+    private final String summary;
+    private final String[] positiveKeywords;
+    private final String[] negativeKeywords;
+    private final String stressReliefSuggestions;
+
+    public static FeedbackResponse from(Feedback feedback){
         return FeedbackResponse.builder()
                 .summary(feedback.getDiarySummary())
                 .positiveKeywords(feedback.getPositiveEmotionArray())

--- a/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/JwtProvider.java
@@ -72,7 +72,7 @@ public class JwtProvider {
         String accessToken = GRANT_TYPE + createAccessToken(email);
         String refreshToken = GRANT_TYPE + createRefreshToken(email);
 
-        return new TokenDto(accessToken, refreshToken);
+        return TokenDto.of(accessToken, refreshToken);
     }
 
     public String createAccessToken(String email) {

--- a/src/main/java/com/konkuk/strhat/domain/user/application/KakaoOAuthService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/KakaoOAuthService.java
@@ -33,9 +33,9 @@ public class KakaoOAuthService {
         if(user.isPresent()){
             TokenDto tokenDto = jwtProvider.createAllToken(user.get().getEmail());
             jwtProvider.setResponseHeaderToken(httpServletResponse, tokenDto);
-            return new PostKakaoSignInResponse(true, email);
+            return PostKakaoSignInResponse.of(true, email);
         }
-        return new PostKakaoSignInResponse(false, email);
+        return PostKakaoSignInResponse.of(false, email);
     }
 
     private Map<String, Object> getUserAttributesByToken(String kakaoToken){

--- a/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
@@ -32,9 +32,8 @@ public class UserService {
 
     @Transactional
     public TokenDto createUser(PostSignUpRequest request, HttpServletResponse httpServletResponse) {
-        Optional<User> duplicateUser = userRepository.findByEmail(request.getEmail());
 
-        if (duplicateUser.isPresent()) {
+        if (userRepository.existsByEmail(request.getEmail())) {
             throw new DuplicateEmailException();
         }
 

--- a/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
@@ -61,7 +61,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        return new GetUserInfoResponse(
+        return GetUserInfoResponse.of(
                 user.getNickname(),
                 user.getBirth(),
                 user.getGender().toString(),

--- a/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
@@ -37,17 +37,9 @@ public class UserService {
             throw new DuplicateEmailException();
         }
 
-        User user = new User(request.getEmail(),
-                request.getNickname(),
-                request.getBirth(),
-                Gender.toGender(request.getGender()),
-                Job.toJob(request.getJob()),
-                request.getHobbyHealingStyle(),
-                request.getHobbyHealingStyle(),
-                request.getPersonality()
-        );
-
+        User user = request.toUserEntity();
         userRepository.save(user);
+
         TokenDto tokenDto = jwtProvider.createAllToken(request.getEmail());
         RefreshToken refreshToken = new RefreshToken(tokenDto.getRefreshToken(), request.getEmail());
         refreshTokenRepository.save(refreshToken);

--- a/src/main/java/com/konkuk/strhat/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dao/UserRepository.java
@@ -8,5 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
     Optional<User> findById(Long id);
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/GetUserInfoResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/GetUserInfoResponse.java
@@ -1,35 +1,34 @@
 package com.konkuk.strhat.domain.user.dto;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class GetUserInfoResponse {
-    private String nickname;
-    private Integer birth;
-    private String gender;
-    private String job;
-    private String hobbyHealingStyle;
-    private String stressReliefStyle;
-    private String personality;
+    private final String nickname;
+    private final Integer birth;
+    private final String gender;
+    private final String job;
+    private final String hobbyHealingStyle;
+    private final String stressReliefStyle;
+    private final String personality;
 
-    @Builder
-    public GetUserInfoResponse(String nickname,
-                               Integer birth,
-                               String gender,
-                               String job,
-                               String hobbyHealingStyle,
-                               String stressReliefStyle,
-                               String personality) {
-        this.nickname = nickname;
-        this.birth = birth;
-        this.gender = gender;
-        this.job = job;
-        this.hobbyHealingStyle = hobbyHealingStyle;
-        this.stressReliefStyle = stressReliefStyle;
-        this.personality = personality;
+    public static GetUserInfoResponse of(String nickname, Integer birth, String gender, String job,
+                                         String hobbyHealingStyle, String stressReliefStyle, String personality) {
+        return GetUserInfoResponse.builder()
+                .nickname(nickname)
+                .birth(birth)
+                .gender(gender)
+                .job(job)
+                .hobbyHealingStyle(hobbyHealingStyle)
+                .stressReliefStyle(stressReliefStyle)
+                .personality(personality)
+                .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInRequest.java
@@ -1,11 +1,12 @@
 package com.konkuk.strhat.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostKakaoSignInRequest {
     @NotBlank
     private String kakaoAccessToken;

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostKakaoSignInResponse.java
@@ -1,20 +1,21 @@
 package com.konkuk.strhat.domain.user.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class PostKakaoSignInResponse {
 
-    private boolean userExists;
-    private String email;
+    private final boolean userExists;
+    private final String email;
 
-    @Builder
-    public PostKakaoSignInResponse(boolean userExists, String email) {
-        this.userExists = userExists;
-        this.email = email;
+    public static PostKakaoSignInResponse of(boolean userExists, String email) {
+        return PostKakaoSignInResponse.builder()
+                .userExists(userExists)
+                .email(email)
+                .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -5,12 +5,13 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostSignUpRequest {
 
     @NotBlank

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/PostSignUpRequest.java
@@ -1,5 +1,8 @@
 package com.konkuk.strhat.domain.user.dto;
 
+import com.konkuk.strhat.domain.user.entity.User;
+import com.konkuk.strhat.domain.user.enums.Gender;
+import com.konkuk.strhat.domain.user.enums.Job;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -44,4 +47,17 @@ public class PostSignUpRequest {
     @NotBlank
     @Length(min = 20, max = 1000)
     private String personality;
+
+    public User toUserEntity() {
+        return User.builder()
+                .email(this.email)
+                .nickname(this.nickname)
+                .birth(this.birth)
+                .gender(Gender.toGender(this.gender))
+                .job(Job.toJob(this.job))
+                .hobbyHealingStyle(this.hobbyHealingStyle)
+                .stressReliefStyle(this.stressReliefStyle)
+                .personality(this.personality)
+                .build();
+    }
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/TokenDto.java
@@ -1,21 +1,22 @@
 package com.konkuk.strhat.domain.user.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
 public class TokenDto {
 
     private String accessToken;
     private String refreshToken;
 
-    @Builder
-    public TokenDto(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
+    public static TokenDto of(String accessToken, String refreshToken) {
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     public static TokenDto empty() {

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/UserInfoDto.java
@@ -3,12 +3,17 @@ package com.konkuk.strhat.domain.user.dto;
 import com.konkuk.strhat.domain.user.entity.User;
 import com.konkuk.strhat.domain.user.enums.Gender;
 import com.konkuk.strhat.domain.user.enums.Job;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import static lombok.AccessLevel.PRIVATE;
+
 @Getter
-@Builder
-public class UserInfo {
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+public class UserInfoDto {
 
     private final String nickname;
     private final Integer birth;
@@ -18,8 +23,8 @@ public class UserInfo {
     private final String stressReliefStyle;
     private final String personality;
 
-    public static UserInfo from(User user) {
-        return UserInfo.builder()
+    public static UserInfoDto from(User user) {
+        return UserInfoDto.builder()
                 .nickname(user.getNickname())
                 .birth(user.getBirth())
                 .gender(user.getGender())


### PR DESCRIPTION
### ✏️ 이슈 번호
- #37

### ⛳ 작업 분류
- [x] Entity, Response DTO, Request DTO 코드 컨벤션 적용

### 🔨 작업 상세 내용
1. Entity 컨벤션 적용 여부 점검  
2. Response DTO 컨벤션 적용  
3. Request DTO 컨벤션 적용
4. 그 외 자잘한 리팩토링 
    - 객체를 얻을 필요 없이 중복 여부만 검사하는 부분을 findByEmail 에서 existsByEmail 으로 변경해, 성능면에서 더 효율적인 방법으로 개선했습니다.

### 💡 생각해볼 문제
- 코드 컨벤션은 저번에 논의한 것과 동일한데, 나름대로 알아보고 조금 더 보완해서 문서화해보았습니다. ([노션링크!](https://periodic-force-7f0.notion.site/DTO-Entity-1e71f27f3d2d80799573e58bac121cf1?pvs=4)) 혹시 이 내용에서 반대 의견이나 더 좋은 의견 등이 있다면 편하게 말씀해주세요! 다시 고쳐보겠습니다~~
- java 17인 만큼 불변 객체는 class가 아닌 record 로 변경하는 것도 고민해보면 좋을 것 같습니다.
- 서버 ↔ 클라이언트 간에 사용되는 DTO 네이밍과, 클라이언트 개입 없이 서버 ↔ GPT API 간 통신에 사용되는 DTO의 네이밍 규칙을 동일하게 적용할지에 대한 고민이 있습니다. 예를 들어, 클라이언트로부터 컨트롤러에서 받는 DTO도 ~Request, GPT API에 요청을 보낼 때 사용하는 DTO도 ~Request라고 하면, 서버 입장에서는 하나는 입력이고 다른 하나는 출력인데 네이밍이 동일해 역할을 혼동할 여지가 있다고 생각됩니다. 이 부분은 추후 기능 추가하면서 GPT 관련 로직을 건드릴 때 다시 한번 고민해보고 리팩토링할 예정입니다. 혹시 이와 관련해 좋은 아이디어가 있다면 공유 부탁드립니다!
- 스트레스 점수 API 는 이번 주말 내로 구현해서 PR 올리겠습니다!