### PR TITLE
[FEAT] 챗봇 대화 기능 API 구현

### DIFF
--- a/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatPrompt.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatPrompt.java
@@ -1,0 +1,62 @@
+package com.konkuk.strhat.ai.prompt.chat;
+
+import com.konkuk.strhat.ai.dto.GptRequestMessage;
+import com.konkuk.strhat.ai.prompt.GptPrompt;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.konkuk.strhat.ai.prompt.chat.ChatPrompt.ChatResponseFieldNames.RESPONSE;
+
+@RequiredArgsConstructor
+public class ChatPrompt implements GptPrompt {
+
+    private final ChatRequestDto request;
+
+    @Override
+    public List<GptRequestMessage> toMessages() {
+        return List.of(
+                GptRequestMessage.system(String.format("""
+                    당신은 사용자와 대화하며 사용자의 마음을 돌봐주는 %s 챗봇입니다.
+                    """, request.getChatMode())),
+                GptRequestMessage.user(String.format("""
+                    [Input]
+                    1. 사용자 성향 정보: %s
+                    2. 오늘의 일기 내용: %s
+                    3. 오늘의 이전 대화 내역: %s
+                    4. 너가 지금 답해야하는 지금 사용자의 말: %s
+                    """, request.getUserTraits(), request.getDiaryContent(), request.getChatLog(), request.getUserChatMessage())),
+                GptRequestMessage.assistant(String.format("""
+                    [응답 프롬프트]
+                     1. 문장은 한국어 및 친근한 반말로 작성한다.
+                     2. 응답은 반드시 1문장으로만 작성한다.
+                     3. 응답은 아래 JSON 형식을 정확히 따라야 한다:
+                     {
+                         "%s": "답변 1문장"
+                     }
+                     4. 대화내역을 보고 중복된 말은 피한다. '지금 사용자의 말'에 답하며 자연스럽게 사람처럼 대화한다.
+                     5. 사용자가 오늘 있었던 일 중에 긍정 요소를 찾을 수 있도록 질문을 던지는 것도 필요하다.
+                     6. 모드별 답변 스타일:
+                        - 공감 모드: 해결책보다는 사용자의 감정에 진심으로 '이해,위로,공감,응원,격려'하는 짧은 답변.
+                        - 해결책 모드: 간단한 '공감'과 함께 구체적인 '해결책'을 제시.
+                     [공감 모드 예시 응답, 참고용]
+                     {
+                         "%s": "친한 친구랑 싸운 상황이면 누구라도 충분히 속상할 것 같아."
+                     }
+                     [해결책 모드 예시 응답, 참고용]
+                     {
+                         "%s": "우선 친구한테 솔직하게 먼저 이야기를 꺼내보는 건 어때?"
+                     }
+                    """,
+                        RESPONSE,
+                        RESPONSE,
+                        RESPONSE
+                ))
+        );
+    }
+
+    public static class ChatResponseFieldNames {
+        public static final String RESPONSE = "chat_response";
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatRequestDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatRequestDto.java
@@ -1,0 +1,60 @@
+package com.konkuk.strhat.ai.prompt.chat;
+
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import com.konkuk.strhat.domain.user.dto.UserInfoDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class ChatRequestDto {
+
+    @NotBlank(message = "userTraits는 필수입니다.")
+    private final String userTraits;
+
+    @NotBlank(message = "diaryContent는 필수입니다.")
+    private final String diaryContent;
+
+    private final List<String> chatLog;
+
+    @NotBlank(message = "chatMode는 필수입니다.")
+    private final String chatMode;
+
+    @NotBlank(message = "userChatMessage는 필수입니다.")
+    private final String userChatMessage;
+
+    public static ChatRequestDto of(UserInfoDto userInfoDto, String diaryContent, List<ChatMessage> chatMessageList, String userChatMessage) {
+        List<String> chatLog = new ArrayList<>();
+        String chatMode = "";
+        for (ChatMessage chatMessage : chatMessageList){
+            chatLog.add(chatMessage.getSender().getDescription() + ": " + chatMessage.getContent());
+            chatMode = chatMessage.getChatMode().getDescription();
+        }
+
+        return ChatRequestDto.builder()
+                .userTraits(buildUserTraits(userInfoDto))
+                .diaryContent(diaryContent)
+                .chatLog(chatLog)
+                .chatMode(chatMode)
+                .userChatMessage(userChatMessage)
+                .build();
+    }
+
+    private static String buildUserTraits(UserInfoDto user) {
+        return String.format(
+                "[닉네임]: %s, [출생년도]: %d, [성별]: %s, [직업]: %s, [취미 및 힐링 방법]: %s, [스트레스 해소 스타일]: %s, [성격]: %s",
+                user.getNickname(),
+                user.getBirth(),
+                user.getGender(),
+                user.getJob(),
+                user.getHobbyHealingStyle(),
+                user.getStressReliefStyle(),
+                user.getPersonality()
+        );
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatResponseDto.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/chat/ChatResponseDto.java
@@ -1,0 +1,20 @@
+package com.konkuk.strhat.ai.prompt.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.konkuk.strhat.domain.chat.exception.InvalidChatResultException;
+import lombok.Getter;
+
+import static com.konkuk.strhat.ai.prompt.chat.ChatPrompt.ChatResponseFieldNames.*;
+
+@Getter
+public class ChatResponseDto {
+
+    @JsonProperty(RESPONSE)
+    private String chatResponse;
+
+    public void validateResult() {
+        if (this.chatResponse == null || this.chatResponse.isBlank()){
+            throw new InvalidChatResultException(chatResponse);
+        }
+    }
+}

--- a/src/main/java/com/konkuk/strhat/ai/prompt/stress_score/DailyStressScorePrompt.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/stress_score/DailyStressScorePrompt.java
@@ -20,8 +20,8 @@ public class DailyStressScorePrompt implements GptPrompt {
                 GptRequestMessage.user(String.format("""
                     [Input]
                     1. 사용자 성향 정보: %s
-                    1. 오늘의 일기 내용: %s
-                    2. 오늘의 대화 내역: %s
+                    2. 오늘의 일기 내용: %s
+                    3. 오늘의 대화 내역: %s
                     """, request.getUserTraits(), request.getDiaryContent(), request.getChatLog())),
                 GptRequestMessage.assistant(String.format("""
                     [Response Instructions]

--- a/src/main/java/com/konkuk/strhat/ai/prompt/stress_score/WeeklyStressSummaryPrompt.java
+++ b/src/main/java/com/konkuk/strhat/ai/prompt/stress_score/WeeklyStressSummaryPrompt.java
@@ -20,8 +20,8 @@ public class WeeklyStressSummaryPrompt implements GptPrompt {
                 GptRequestMessage.user(String.format("""
                     [Input]
                     1. 사용자 성향 정보: %s
-                    1. 오늘의 일기 내용: %s
-                    2. 오늘의 대화 내역: %s
+                    2. 오늘의 일기 내용: %s
+                    3. 오늘의 대화 내역: %s
                     """, request.getUserTraits(), request.getDiaryContents(), request.getChatLog())),
                 GptRequestMessage.assistant(String.format("""
                     [Response Instructions]

--- a/src/main/java/com/konkuk/strhat/domain/chat/api/ChatController.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/api/ChatController.java
@@ -1,0 +1,33 @@
+package com.konkuk.strhat.domain.chat.api;
+
+import com.konkuk.strhat.domain.chat.application.AIChatService;
+import com.konkuk.strhat.domain.chat.application.ChatService;
+import com.konkuk.strhat.domain.chat.dto.ChatMessageLogResponse;
+import com.konkuk.strhat.domain.chat.dto.ChatRequest;
+import com.konkuk.strhat.domain.chat.dto.ChatResponse;
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import com.konkuk.strhat.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/diaries/{diaryId}/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+    private final AIChatService aiChatService;
+
+    @PostMapping
+    public ApiResponse<ChatResponse> chat(@PathVariable Long diaryId, @RequestBody ChatRequest request) {
+        ChatMessage userChatMessage = chatService.saveUserChatMessage(diaryId, request);
+        ChatMessage AIChatMessage = aiChatService.chat(userChatMessage);
+        ChatResponse response = chatService.saveAIChatMessage(AIChatMessage);
+        return ApiResponse.success(response);
+    }
+    @GetMapping
+    public ApiResponse<ChatMessageLogResponse> getChatLog(@PathVariable Long diaryId) {
+        ChatMessageLogResponse response = chatService.readChatLog(diaryId);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/application/AIChatService.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/application/AIChatService.java
@@ -1,0 +1,83 @@
+package com.konkuk.strhat.domain.chat.application;
+
+import com.konkuk.strhat.ai.dto.GptReplyResult;
+import com.konkuk.strhat.ai.prompt.chat.ChatPrompt;
+import com.konkuk.strhat.ai.prompt.chat.ChatRequestDto;
+import com.konkuk.strhat.ai.prompt.chat.ChatResponseDto;
+import com.konkuk.strhat.ai.util.GptResponseParser;
+import com.konkuk.strhat.ai.web_client.GptClient;
+import com.konkuk.strhat.domain.chat.dao.ChatMessageRepository;
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import com.konkuk.strhat.domain.chat.enums.ChatMode;
+import com.konkuk.strhat.domain.chat.enums.Sender;
+import com.konkuk.strhat.domain.diary.entity.Diary;
+import com.konkuk.strhat.domain.stressScore.exception.UnknownStressScoreGenerateException;
+import com.konkuk.strhat.domain.user.dto.UserInfoDto;
+import com.konkuk.strhat.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AIChatService {
+    private final GptClient gptClient;
+    private final GptResponseParser gptResponseParser;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatMessage chat(ChatMessage chatMessage){
+        Diary diary = chatMessage.getDiary();
+        List<ChatMessage> previousMessages = chatMessageRepository.findAllByDiary(diary);
+        ChatMode mode = chatMessage.getChatMode();
+        String currentMessage = chatMessage.getContent();
+        return generateChatResponse(diary, previousMessages, mode, currentMessage);
+    }
+
+    private ChatMessage generateChatResponse(Diary diary, List<ChatMessage> previousMessages, ChatMode chatMode, String userChatMessage) {
+        User user = diary.getUser();
+        log.info("[AIChatService] 채팅 응답 생성 요청 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+
+        try {
+            // 1. GPT API 요청에 필요한 DTO 구성
+            log.info("[AIChatService] GPT API 요청에 필요한 DTO 구성 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            ChatRequestDto promptRequest = ChatRequestDto.of(
+                    UserInfoDto.from(diary.getUser()),
+                    diary.getContent(),
+                    previousMessages,
+                    userChatMessage
+            );
+
+            // 2. Prompt 생성 및 요청
+            log.info("[AIChatService] 프롬프트 생성 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            ChatPrompt prompt = new ChatPrompt(promptRequest);
+            log.info("[AIChatService] GPT 요청 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            GptReplyResult result = gptClient.call(prompt);
+
+
+            // 3. GPT 응답 파싱 및 유효성 검증
+            log.info("[AIChatService] GPT 응답 파싱 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            ChatResponseDto chatResponseDto = gptResponseParser.parse(result, ChatResponseDto.class);
+            log.info("[AIChatService] GPT 응답 유효성 검증 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            chatResponseDto.validateResult();
+
+            // 4. StressScore 객체 생성 및 반환
+            log.info("[AIChatService] 채팅 응답 ChatMessage 객체 생성 시작, diaryId={}, userId={}", diary.getId(), user.getId());
+            ChatMessage chatMessage = ChatMessage.builder()
+                    .content(chatResponseDto.getChatResponse())
+                    .sender(Sender.CHAT_BOT)
+                    .diary(diary)
+                    .chatMode(chatMode)
+                    .build();
+            log.info("[AIChatService] 채팅 응답 생성 완료, diaryId={}, userId={}", diary.getId(), user.getId());
+            return chatMessage;
+
+        } catch (Exception e) {
+            log.error("[AIChatService] 채팅 응답 생성 실패, diaryId={}, userId={}", diary.getId(), user.getId());
+            throw new UnknownStressScoreGenerateException(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/konkuk/strhat/domain/chat/application/ChatService.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/application/ChatService.java
@@ -1,0 +1,57 @@
+package com.konkuk.strhat.domain.chat.application;
+
+import com.konkuk.strhat.domain.chat.dto.ChatMessageLogResponse;
+import com.konkuk.strhat.domain.chat.dto.ChatRequest;
+import com.konkuk.strhat.domain.chat.dto.ChatResponse;
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import com.konkuk.strhat.domain.chat.enums.Sender;
+import com.konkuk.strhat.domain.chat.dao.ChatMessageRepository;
+import com.konkuk.strhat.domain.diary.entity.Diary;
+import com.konkuk.strhat.domain.diary.dao.DiaryRepository;
+import com.konkuk.strhat.domain.diary.exception.NotFoundDiaryException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final DiaryRepository diaryRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessage saveUserChatMessage(Long diaryId, ChatRequest request) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(NotFoundDiaryException::new);
+
+        ChatMessage userMessage = ChatMessage.builder()
+                .diary(diary)
+                .sender(Sender.USER)
+                .content(request.getUserMessage())
+                .chatMode(request.getChatMode())
+                .build();
+
+        return saveChatMessages(userMessage);
+    }
+
+    @Transactional
+    public ChatResponse saveAIChatMessage(ChatMessage AIMessage) {
+        saveChatMessages(AIMessage);
+        return ChatResponse.of(AIMessage.getContent());
+    }
+
+    @Transactional(readOnly = true)
+    public ChatMessageLogResponse readChatLog(Long diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(NotFoundDiaryException::new);
+        return ChatMessageLogResponse.from(chatMessageRepository.findAllByDiary(diary));
+    }
+
+    private ChatMessage saveChatMessages(ChatMessage chatMessage) {
+        return chatMessageRepository.save(chatMessage);
+    }
+
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/dao/ChatMessageRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/dao/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.konkuk.strhat.domain.chat.dao;
+
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import com.konkuk.strhat.domain.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findAllByDiary(Diary diary);
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatMessageLogResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatMessageLogResponse.java
@@ -1,0 +1,24 @@
+package com.konkuk.strhat.domain.chat.dto;
+
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageLogResponse {
+    private final List<ChatMessageResponse> chatMessages;
+
+    public static ChatMessageLogResponse from(List<ChatMessage> messageList) {
+        return ChatMessageLogResponse.builder()
+                .chatMessages(messageList.stream()
+                        .map(ChatMessageResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,26 @@
+package com.konkuk.strhat.domain.chat.dto;
+
+import com.konkuk.strhat.domain.chat.entity.ChatMessage;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageResponse {
+    private final String content;
+    private final String sender;
+    private final LocalDateTime createdAt;
+
+    public static ChatMessageResponse from(ChatMessage message) {
+        return ChatMessageResponse.builder()
+                .content(message.getContent())
+                .sender(message.getSender().name())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatRequest.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatRequest.java
@@ -1,0 +1,19 @@
+package com.konkuk.strhat.domain.chat.dto;
+
+import com.konkuk.strhat.domain.chat.enums.ChatMode;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ChatRequest {
+
+    @NotBlank
+    @Length(min = 1, max = 255)
+    private String userMessage;
+
+    @NotBlank
+    private ChatMode chatMode;
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/dto/ChatResponse.java
@@ -1,0 +1,19 @@
+package com.konkuk.strhat.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = lombok.AccessLevel.PRIVATE)
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class ChatResponse {
+
+    private final String message;
+
+    public static ChatResponse of(String message) {
+        return ChatResponse.builder()
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/entity/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.konkuk.strhat.domain.chat.entity;
 
+import com.konkuk.strhat.domain.chat.enums.ChatMode;
 import com.konkuk.strhat.domain.chat.enums.Sender;
 import com.konkuk.strhat.domain.diary.entity.Diary;
 import com.konkuk.strhat.global.entity.BaseCreatedEntity;
@@ -37,14 +38,19 @@ public class ChatMessage extends BaseCreatedEntity {
     @Column(name = "sender", length = 255, nullable = false)
     private Sender sender;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "chat_mode", length = 20, nullable = false)
+    private ChatMode chatMode;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
     @Builder
-    public ChatMessage(String content, Sender sender, Diary diary) {
+    public ChatMessage(String content, Sender sender, Diary diary, ChatMode chatMode) {
         this.content = content;
         this.sender = sender;
         this.diary = diary;
+        this.chatMode = chatMode;
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/chat/enums/ChatMode.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/enums/ChatMode.java
@@ -1,0 +1,13 @@
+package com.konkuk.strhat.domain.chat.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatMode {
+    EMPATHY_MODE("공감 모드"),
+    SOLUTION_MODE("해결책 모드");
+
+    private final String description;
+}

--- a/src/main/java/com/konkuk/strhat/domain/chat/exception/InvalidChatResultException.java
+++ b/src/main/java/com/konkuk/strhat/domain/chat/exception/InvalidChatResultException.java
@@ -1,0 +1,11 @@
+package com.konkuk.strhat.domain.chat.exception;
+
+import com.konkuk.strhat.global.error.CustomException;
+import com.konkuk.strhat.global.error.ErrorCode;
+
+public class InvalidChatResultException extends CustomException {
+
+    public InvalidChatResultException(String content) {
+        super(ErrorCode.INVALID_CHAT_RESULT, "응답 내용: " + content);
+    }
+}

--- a/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/application/DiaryService.java
@@ -37,9 +37,10 @@ public class DiaryService {
         if(diary.isPresent()){
             Integer emotion = diary.get().getEmotion();
             String content = diary.get().getContent();
-            response = CheckDiaryResponse.of(true, emotion, content.substring(0, Math.min(content.length(), 70)));
+            Long diaryId = diary.get().getId();
+            response = CheckDiaryResponse.of(true, emotion, content.substring(0, Math.min(content.length(), 70)), diaryId);
         } else{
-            response = CheckDiaryResponse.of(false, null, null);
+            response = CheckDiaryResponse.of(false, null, null, null);
         }
         return response;
     }
@@ -69,7 +70,9 @@ public class DiaryService {
                 feedback.getDiarySummary(),
                 feedback.getPositiveEmotionArray(),
                 feedback.getNegativeEmotionArray(),
-                feedback.getStressReliefSuggestion());
+                feedback.getStressReliefSuggestion(),
+                feedback.getDiary().getId()
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/CheckDiaryResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/CheckDiaryResponse.java
@@ -13,12 +13,14 @@ public class CheckDiaryResponse {
     private final boolean hasDiary;
     private final Integer emotion;
     private final String summary;
+    private final Long diaryId;
 
-    public static CheckDiaryResponse of(boolean hasDiary, Integer emotion, String summary){
+    public static CheckDiaryResponse of(boolean hasDiary, Integer emotion, String summary, Long diaryId){
         return CheckDiaryResponse.builder()
                 .hasDiary(hasDiary)
                 .emotion(emotion)
                 .summary(summary)
+                .diaryId(diaryId)
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiaryContentResponse.java
@@ -13,10 +13,12 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor(access = PRIVATE)
 public class DiaryContentResponse {
     private final String content;
+    private final Long diaryId;
 
     public static DiaryContentResponse from(Diary diary) {
         return DiaryContentResponse.builder()
                 .content(diary.getContent())
+                .diaryId(diary.getId())
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/DiarySaveResponse.java
@@ -15,13 +15,15 @@ public class DiarySaveResponse {
     private final String[] positiveKeywords;
     private final String[] negativeKeywords;
     private final String stressReliefSuggestions;
+    private final Long diaryId;
 
-    public static DiarySaveResponse of(String summary, String[] positiveKeywords, String[] negativeKeywords, String stressReliefSuggestions){
+    public static DiarySaveResponse of(String summary, String[] positiveKeywords, String[] negativeKeywords, String stressReliefSuggestions, Long diaryId){
         return DiarySaveResponse.builder()
                 .summary(summary)
                 .positiveKeywords(positiveKeywords)
                 .negativeKeywords(negativeKeywords)
                 .stressReliefSuggestions(stressReliefSuggestions)
+                .diaryId(diaryId)
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/diary/dto/FeedbackResponse.java
@@ -16,6 +16,7 @@ public class FeedbackResponse {
     private final String[] positiveKeywords;
     private final String[] negativeKeywords;
     private final String stressReliefSuggestions;
+    private final Long diaryId;
 
     public static FeedbackResponse from(Feedback feedback){
         return FeedbackResponse.builder()
@@ -23,6 +24,7 @@ public class FeedbackResponse {
                 .positiveKeywords(feedback.getPositiveEmotionArray())
                 .negativeKeywords(feedback.getNegativeEmotionArray())
                 .stressReliefSuggestions(feedback.getStressReliefSuggestion())
+                .diaryId(feedback.getDiary().getId())
                 .build();
     }
 }

--- a/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
+++ b/src/main/java/com/konkuk/strhat/global/error/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     INVALID_SUMMARY_SIZE(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 주간 스트레스 요약 결과의 길이가 유효하지 않습니다."),
     INVALID_SUMMARY_RESULT(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 주간 스트레스 요약 결과가 유효하지 않습니다."),
     INVALID_STRESS_SCORE_RESULT(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 일일 스트레스 점수 측정 결과가 유효하지 않습니다."),
+    INVALID_CHAT_RESULT(HttpStatus.BAD_GATEWAY, "A502", "GPT API를 통해 생성된 채팅 결과가 유효하지 않습니다."),
 
     // SELF DIAGNOSIS
     UNSUPPORTED_SELF_DIAGNOSIS_TYPE(HttpStatus.BAD_REQUEST, "S400", "지원하지 않는 설문 형식입니다."),


### PR DESCRIPTION
### ✏️ 이슈 번호
- #44

### ⛳ 작업 분류
- [x] 신규 API 구현

### 🔨 작업 상세 내용
1. 채팅 AI 관련 로직 구현
2. 채팅 하기 API 구현
3. 채팅 내역 조회 API 구현
4. 일기 도메인 관련 모든 API 응답에 diaryId 추가

### 💡 생각해볼 문제
- 요청에 diaryId을 필요로 함에 따라, 일기 도메인 API를 수정했습니다. (노션 명세서 반영 완!)
- 답변 프롬프팅은 .. 조금 개선이 필요할 듯 합니다