### PR TITLE
[FIX] 로그아웃 API 오류 수정

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
     @Transactional
     public void processSignOut(Long kakaoId) {
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByKakaoId(kakaoId);
-        refreshToken.ifPresent(refreshTokenRepository::deleteAll);
+        refreshToken.ifPresent(refreshTokenRepository::delete);
     }
 
     @Transactional

--- a/src/main/java/com/konkuk/strhat/domain/user/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dao/RefreshTokenRepository.java
@@ -8,5 +8,4 @@ public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Str
 
     Optional<RefreshToken> findByKakaoId(Long kakaoId);
 
-    void deleteAll(RefreshToken refreshToken);
 }


### PR DESCRIPTION
### ✏️ 이슈 번호
- #55 

### ⛳ 작업 분류
- [x] 작업1 로그아웃 API 오류 해결

### 🔨 작업 상세 내용
1. RefreshToken 단일 삭제를 해야하는 경우였는데 deleteAll 메소드로 작동하고 있어 오류가 발생하고 있었습니다.

### 💡 생각해볼 문제
X
