### PR TITLE
[FIX] 자가진단 API 오류 수정

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/api/SelfDiagnosisController.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/api/SelfDiagnosisController.java
@@ -40,8 +40,9 @@ public class SelfDiagnosisController {
 
     @GetMapping("/result")
     public ApiResponse<GetSelfDiagnosisResultResponse> readSelfDiagnosisResult(
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-        GetSelfDiagnosisResultResponse response = selfDiagnosisService.findSelfDiagnosisResult(date, SecurityUtil.getCurrentUserId());
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+            @RequestParam String type) {
+        GetSelfDiagnosisResultResponse response = selfDiagnosisService.findSelfDiagnosisResult(date, SecurityUtil.getCurrentUserId(), type);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/application/SelfDiagnosisService.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/application/SelfDiagnosisService.java
@@ -37,9 +37,9 @@ public class SelfDiagnosisService {
 
     public List<GetSelfDiagnosisQuestion> findSelfDiagnosis(String type) {
         return switch (type) {
-            case "pss"   -> pssQuestionList();
-            case "sri"   -> sriQuestionList();
-            case "phq-9" -> phq9QuestionList();
+            case "pss", "PSS"   -> pssQuestionList();
+            case "sri", "SRI"   -> sriQuestionList();
+            case "phq9", "PHQ9" -> phq9QuestionList();
             default      -> throw new UnsupportedSelfDiagnosisTypeException();
         };
     }

--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/application/SelfDiagnosisService.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/application/SelfDiagnosisService.java
@@ -49,7 +49,10 @@ public class SelfDiagnosisService {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        Optional<SelfDiagnosis> optionalSelfDiagnosis = selfDiagnosisRepository.findBySelfDiagnosisDateAndUser(LocalDate.now(), user);
+        Optional<SelfDiagnosis> optionalSelfDiagnosis =
+                selfDiagnosisRepository.findBySelfDiagnosisDateAndUserAndType(LocalDate.now(), user,
+                        SelfDiagnosisType.toSelfDiagnosisType(request.getType()));
+
         if (optionalSelfDiagnosis.isPresent()) {
             throw new DuplicateSelfDiagnosisException();
         }
@@ -64,11 +67,12 @@ public class SelfDiagnosisService {
     }
 
     @Transactional(readOnly = true)
-    public GetSelfDiagnosisResultResponse findSelfDiagnosisResult(LocalDate date, Long userId) {
+    public GetSelfDiagnosisResultResponse findSelfDiagnosisResult(LocalDate date, Long userId, String type) {
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        SelfDiagnosis selfDiagnosis = selfDiagnosisRepository.findBySelfDiagnosisDateAndUser(date, user)
+        SelfDiagnosis selfDiagnosis = selfDiagnosisRepository
+                .findBySelfDiagnosisDateAndUserAndType(date, user, SelfDiagnosisType.toSelfDiagnosisType(type))
                 .orElseThrow(NotFoundSelfDiagnosisException::new);
 
         String selfDiagnosisLevel = switch (selfDiagnosis.getType()) {

--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/dao/SelfDiagnosisRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/dao/SelfDiagnosisRepository.java
@@ -1,6 +1,7 @@
 package com.konkuk.strhat.domain.selfDiagnosis.dao;
 
 import com.konkuk.strhat.domain.selfDiagnosis.entity.SelfDiagnosis;
+import com.konkuk.strhat.domain.selfDiagnosis.enums.SelfDiagnosisType;
 import com.konkuk.strhat.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +10,5 @@ import java.util.Optional;
 
 public interface SelfDiagnosisRepository extends JpaRepository<SelfDiagnosis, Long> {
 
-    Optional<SelfDiagnosis> findBySelfDiagnosisDateAndUser(LocalDate date, User user);
+    Optional<SelfDiagnosis> findBySelfDiagnosisDateAndUserAndType(LocalDate date, User user, SelfDiagnosisType type);
 }

--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/entity/SelfDiagnosis.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/entity/SelfDiagnosis.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @Table(
         name = "self_diagnosis",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "self_diagnosis_date"})
+                @UniqueConstraint(columnNames = {"user_id", "self_diagnosis_date", "type"})
         }
 )
 @Getter


### PR DESCRIPTION
### ✏️ 이슈 번호
- #59 

### ⛳ 작업 분류
- [x] 작업1 자가진단 타입 형식 동일하게 변경
- [x] 작업2 자가진단 Unique 제약 변경
- [x] 작업3 결과 조회 시 type QueryParameter 추가

### 🔨 작업 상세 내용
1. 자가진단 타입을 입력받을 때 데이터 조회 시에는 "phq-9"으로, 결과 저장 시에는 "phq9"로 저장하고 있어 해당 형식을 동일하게 변경하였습니다.(phq9)
2. 확인해보니 자가진단 테이블의 Unique 제약에 Type이 반영이 안되어 있어 이를 추가하였습니다. DB에 반영해야할 사항은 다음과 같습니다.

- 자가진단 유니크 인덱스 확인
```sql
SHOW INDEX
  FROM self_diagnosis
 WHERE Non_unique = 0
   AND Key_name <> 'PRIMARY';
```

- 기존 유니크 인덱스 제거
``` sql
ALTER TABLE self_diagnosis
  DROP INDEX "기존 유니크 인덱스 Key_Name";
```

- 타입 반영 새로운 유니크 인덱스 추가
``` sql
ALTER TABLE self_diagnosis
  ADD CONSTRAINT UK_user_date_type
    UNIQUE (user_id, self_diagnosis_date, type);
```

3. 결과 조회 시 type을 추가로 입력받도록 변경하였습니다.

### 💡 생각해볼 문제
- DB 반영만 해주시면 될 것 같습니다.
