### PR TITLE
[REFACTOR] 홈 API 리뷰 반영 및 Response 변경

### DIFF
--- a/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/api/SelfDiagnosisController.java
+++ b/src/main/java/com/konkuk/strhat/domain/selfDiagnosis/api/SelfDiagnosisController.java
@@ -5,6 +5,7 @@ import com.konkuk.strhat.domain.selfDiagnosis.dto.GetSelfDiagnosisResultResponse
 import com.konkuk.strhat.domain.selfDiagnosis.dto.PostSelfDiagnosisRequest;
 import com.konkuk.strhat.domain.selfDiagnosis.dto.GetSelfDiagnosisQuestion;
 import com.konkuk.strhat.global.response.ApiResponse;
+import com.konkuk.strhat.global.response.ApiResponseTempOnly;
 import com.konkuk.strhat.global.util.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +34,9 @@ public class SelfDiagnosisController {
     }
 
     @PostMapping("")
-    public ApiResponse<Void> createSelfDiagnosisResult(@Valid @RequestBody PostSelfDiagnosisRequest request) {
+    public ApiResponseTempOnly createSelfDiagnosisResult(@Valid @RequestBody PostSelfDiagnosisRequest request) {
         selfDiagnosisService.generateSelfDiagnosisResult(request, SecurityUtil.getCurrentUserId());
-        return ApiResponse.successOnly();
+        return ApiResponseTempOnly.successTempOnly();
     }
 
     @GetMapping("/result")

--- a/src/main/java/com/konkuk/strhat/domain/stressScore/dao/StressScoreRepository.java
+++ b/src/main/java/com/konkuk/strhat/domain/stressScore/dao/StressScoreRepository.java
@@ -7,22 +7,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.util.Optional;
 
 public interface StressScoreRepository extends JpaRepository<StressScore, Long> {
-
     @Query("""
-                SELECT ss
-                  FROM StressScore ss, Diary d
-                 WHERE d.stressScore = ss
-                   AND d = :diary
-                   AND d.user = :user
-                   AND ss.stressScoreDate = :date
-            """)
-    Optional<StressScore> findByDiaryAndUserAndStressScoreDate(
+        SELECT ss 
+        FROM StressScore ss, Diary d
+        WHERE d.stressScore = ss
+        AND d = :diary
+        AND d.user = :user
+    """)
+    Optional<StressScore> findByDiaryAndUser(
             @Param("diary") Diary diary,
-            @Param("user") User user,
-            @Param("date") LocalDate date
+            @Param("user") User user
     );
 }

--- a/src/main/java/com/konkuk/strhat/domain/user/application/HomeService.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/application/HomeService.java
@@ -39,7 +39,7 @@ public class HomeService {
 
         Optional<Feedback> feedback = feedbackRepository.findByDiary(diary.get());
         Optional<StressScore> stressScore = stressScoreRepository
-                .findByDiaryAndUserAndStressScoreDate(diary.get(), user, LocalDate.now());
+                .findByDiaryAndUser(diary.get(), user);
 
         if (feedback.isEmpty() && stressScore.isEmpty()) {
             return GetHomeResponse.of(user, diary.get());

--- a/src/main/java/com/konkuk/strhat/domain/user/dto/GetHomeResponse.java
+++ b/src/main/java/com/konkuk/strhat/domain/user/dto/GetHomeResponse.java
@@ -5,11 +5,12 @@ import com.konkuk.strhat.domain.diary.entity.Feedback;
 import com.konkuk.strhat.domain.stressScore.entity.StressScore;
 import com.konkuk.strhat.domain.stressScore.exception.ScoreOutOfRangeException;
 import com.konkuk.strhat.domain.user.entity.User;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class GetHomeResponse {
 
     private boolean hasDiary;

--- a/src/main/java/com/konkuk/strhat/global/response/ApiResponseTempOnly.java
+++ b/src/main/java/com/konkuk/strhat/global/response/ApiResponseTempOnly.java
@@ -1,0 +1,22 @@
+package com.konkuk.strhat.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({ "isSuccess", "response" })
+public class ApiResponseTempOnly {
+
+    @JsonProperty("isSuccess")
+    private final boolean success = true;
+
+    @JsonProperty("response")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Object response = null;
+
+    private ApiResponseTempOnly() {}
+
+    public static ApiResponseTempOnly successTempOnly() {
+        return new ApiResponseTempOnly();
+    }
+}


### PR DESCRIPTION
### ✏️ 이슈 번호
- #54 

### ⛳ 작업 분류
- [ ] 작업1 빌더 Private 설정
- [ ] 작업2 StressScore 조회 쿼리 변경
- [ ] 작업3 자가진단 API Response 변경

### 🔨 작업 상세 내용
1. GetHomeResponse의 빌더를 Private으로 설정하였습니다.
2. StressScore를 Diary와 User 정보로만 조회하도록 변경하였습니다.
3. 자가진단 API의 Response의 "response"값을 포함하였습니다.

### 💡 생각해볼 문제
-Response 변경의 경우 내용이 많지 않아 해당 PR에 포함하게 되었습니다.
- 기존에 존재하던 ApiResponse에 메소드를 추가하고 싶었지만, JsonInclude 설정이 기존에 존재하던 `successOnly(`) 메소드와 충돌되어 사용중이던 응답에 영향을 주지 않기 위해 부득이하게 클래스를 새로 만들게 되었습니다.
